### PR TITLE
Changing Primary Keys to UUIds

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,8 +1,5 @@
 class Membership < ActiveRecord::Base
-  include StringIdCreator
 
-  before_create :create_string_id
-  self.primary_key = 'id'
   belongs_to :user
   belongs_to :project
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,5 @@
 class Project < ActiveRecord::Base
 
-  before_create :create_string_id
   after_save :add_project_admin_role_to_user
   after_initialize :init
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,4 @@
 class Project < ActiveRecord::Base
-  include StringIdCreator
-  self.primary_key = 'id'
 
   before_create :create_string_id
   after_save :add_project_admin_role_to_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,7 @@
 require 'jwt'
 
 class User < ActiveRecord::Base
-  include StringIdCreator
 
-  before_create :create_string_id
-  self.primary_key = 'id'
   has_many :user_authentication_services
   accepts_nested_attributes_for :user_authentication_services
 

--- a/db/migrate/20150817150440_change_primary_keys_to_uuids.rb
+++ b/db/migrate/20150817150440_change_primary_keys_to_uuids.rb
@@ -1,0 +1,45 @@
+class ChangePrimaryKeysToUuids < ActiveRecord::Migration
+  def change
+    drop_table :users
+    create_table :users, id: :uuid  do |t|
+      t.string :etag
+      t.string :email
+      t.string :display_name
+      t.jsonb :auth_role_ids
+      t.string :first_name
+      t.string :last_name
+
+      t.timestamps null: false
+    end
+
+    drop_table :projects
+    create_table :projects, id: :uuid  do |t|
+      t.string :name
+      t.string :description
+      t.uuid :creator_id
+      t.string :etag
+      t.boolean :is_deleted
+
+      t.timestamps null: false
+    end
+
+    drop_table :memberships
+    create_table :memberships, id: :uuid  do |t|
+      t.uuid :user_id
+      t.uuid :project_id
+
+      t.timestamps null: false
+    end
+
+    remove_column :folders, :project_id, :string
+    add_column :folders, :project_id, :uuid
+    remove_column :project_permissions, :user_id, :string
+    add_column :project_permissions, :user_id, :uuid
+    remove_column :project_permissions, :project_id, :string
+    add_column :project_permissions, :project_id, :uuid
+    remove_column :storage_folders, :project_id, :string
+    add_column :storage_folders, :project_id, :uuid
+    remove_column :user_authentication_services, :user_id, :string
+    add_column :user_authentication_services, :user_id, :uuid
+  end
+end

--- a/db/migrate/20150817180158_add_deleted_at_to_projects.rb
+++ b/db/migrate/20150817180158_add_deleted_at_to_projects.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150817150440) do
+ActiveRecord::Schema.define(version: 20150817180158) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,7 @@ ActiveRecord::Schema.define(version: 20150817150440) do
     t.boolean  "is_deleted"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.datetime "deleted_at"
   end
 
   create_table "storage_folders", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150813145323) do
+ActiveRecord::Schema.define(version: 20150817150440) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,51 +52,44 @@ ActiveRecord::Schema.define(version: 20150813145323) do
   create_table "folders", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.string   "name"
     t.uuid     "parent_id"
-    t.string   "project_id"
     t.boolean  "is_deleted"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid     "project_id"
   end
 
-  create_table "memberships", id: false, force: :cascade do |t|
-    t.string   "id",         null: false
-    t.string   "user_id"
-    t.string   "project_id"
+  create_table "memberships", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
+    t.uuid     "user_id"
+    t.uuid     "project_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  add_index "memberships", ["id"], name: "index_memberships_on_id", unique: true, using: :btree
-
   create_table "project_permissions", force: :cascade do |t|
-    t.string   "project_id"
-    t.string   "user_id"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
     t.integer  "auth_role_id"
+    t.uuid     "user_id"
+    t.uuid     "project_id"
   end
 
-  create_table "projects", id: false, force: :cascade do |t|
-    t.string   "id",          null: false
+  create_table "projects", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.string   "name"
     t.string   "description"
-    t.string   "creator_id"
+    t.uuid     "creator_id"
     t.string   "etag"
     t.boolean  "is_deleted"
-    t.datetime "deleted_at"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
   end
 
-  add_index "projects", ["id"], name: "index_projects_on_id", unique: true, using: :btree
-
   create_table "storage_folders", force: :cascade do |t|
-    t.string   "project_id"
     t.string   "name"
     t.text     "description"
     t.string   "storage_service_uuid"
     t.datetime "created_at",           null: false
     t.datetime "updated_at",           null: false
+    t.uuid     "project_id"
   end
 
   create_table "storage_providers", force: :cascade do |t|
@@ -125,15 +118,14 @@ ActiveRecord::Schema.define(version: 20150813145323) do
   end
 
   create_table "user_authentication_services", force: :cascade do |t|
-    t.string   "user_id"
     t.integer  "authentication_service_id"
     t.string   "uid"
     t.datetime "created_at",                null: false
     t.datetime "updated_at",                null: false
+    t.uuid     "user_id"
   end
 
-  create_table "users", id: false, force: :cascade do |t|
-    t.string   "id",            null: false
+  create_table "users", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.string   "etag"
     t.string   "email"
     t.string   "display_name"
@@ -143,7 +135,5 @@ ActiveRecord::Schema.define(version: 20150813145323) do
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
   end
-
-  add_index "users", ["id"], name: "index_users_on_id", unique: true, using: :btree
 
 end


### PR DESCRIPTION
The primary keys for users, projects, and memberships were changed to UUIds from strings by dropping and creating respective tables. Resulting required changes to foreign key types were also made.