### PR TITLE
heroku recently enacted a policy to reject pushes from shallow clones

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,16 +32,18 @@ deployment:
  development:
    branch: develop
    commands:
-    #  - heroku run --exit-code rake assets:clobber --app 'dukeds-dev'
-     - git push git@heroku.com:dukeds-dev.git $CIRCLE_SHA1:refs/heads/master:
-         timeout: 54000
-     - heroku run --exit-code rake db:migrate --app 'dukeds-dev'
-     - heroku run --exit-code rake db:seed --app 'dukeds-dev'
+    # - heroku run --exit-code rake assets:clobber --app 'dukeds-dev'
+    - "[[ ! -s \"$(git rev-parse --git-dir)/shallow\" ]] || git fetch --unshallow"
+    - git push git@heroku.com:dukeds-dev.git $CIRCLE_SHA1:refs/heads/master:
+        timeout: 54000
+    - heroku run --exit-code rake db:migrate --app 'dukeds-dev'
+    - heroku run --exit-code rake db:seed --app 'dukeds-dev'
  ua_test:
    branch: ua_test
    commands:
-    #  - heroku run --exit-code rake assets:clobber --app 'dukeds-uatest'
-     - git push git@heroku.com:dukeds-uatest.git $CIRCLE_SHA1:refs/heads/master:
-         timeout: 54000
-     - heroku run --exit-code rake db:migrate --app 'dukeds-uatest'
-     - heroku run --exit-code rake db:seed --app 'dukeds-uatest'
+    # - heroku run --exit-code rake assets:clobber --app 'dukeds-uatest'
+    - "[[ ! -s \"$(git rev-parse --git-dir)/shallow\" ]] || git fetch --unshallow"
+    - git push git@heroku.com:dukeds-uatest.git $CIRCLE_SHA1:refs/heads/master:
+        timeout: 54000
+    - heroku run --exit-code rake db:migrate --app 'dukeds-uatest'
+    - heroku run --exit-code rake db:seed --app 'dukeds-uatest'


### PR DESCRIPTION
https://devcenter.heroku.com/changelog-items/775

circleci suggested a workaround while they address the situation
https://discuss.circleci.com/t/git-errors-failing-the-build-when-deploying-to-heroku/776
