### PR TITLE
Upload content_type and name of the upload are stored on the swift SLO manifest object

### DIFF
--- a/app/models/storage_provider.rb
+++ b/app/models/storage_provider.rb
@@ -19,14 +19,17 @@ class StorageProvider < ActiveRecord::Base
     call_auth_uri['x-storage-url']
   end
 
+  def auth_header
+    {'X-Auth-Token' => auth_token}
+  end
+
   def register_keys
     resp = HTTParty.post(
       storage_url,
-      headers:{
-        'X-Auth-Token' => auth_token,
+      headers: auth_header.merge({
         'X-Account-Meta-Temp-URL-Key' => primary_key,
         'X-Account-Meta-Temp-URL-Key-2' => secondary_key
-      }
+      })
     )
     (resp.response.code.to_i == 204) || raise(StorageProviderException, resp.body)
   end
@@ -60,7 +63,7 @@ class StorageProvider < ActiveRecord::Base
   def get_account_info
     resp = HTTParty.get(
       "#{storage_url}",
-      headers:{"X-Auth-Token" => auth_token}
+      headers: auth_header
     )
     ([200,204].include?(resp.response.code.to_i)) ||
       raise(StorageProviderException, resp.body)
@@ -70,10 +73,9 @@ class StorageProvider < ActiveRecord::Base
   def put_container(container)
     resp = HTTParty.put(
       "#{storage_url}/#{container}",
-      headers:{
-        "X-Auth-Token" => auth_token,
+      headers: auth_header.merge({
         "X-Container-Meta-Access-Control-Allow-Origin" => "*"
-      }
+      })
     )
     ([201,202,204].include?(resp.response.code.to_i)) ||
       raise(StorageProviderException, resp.body)
@@ -82,7 +84,7 @@ class StorageProvider < ActiveRecord::Base
   def delete_container(container)
     resp = HTTParty.delete(
       "#{storage_url}/#{container}",
-      headers:{"X-Auth-Token" => auth_token}
+      headers: auth_header
     )
     ([204].include?(resp.response.code.to_i)) ||
       raise(StorageProviderException, resp.body)
@@ -92,17 +94,24 @@ class StorageProvider < ActiveRecord::Base
     resp = HTTParty.put(
       "#{storage_url}/#{container}/#{object}",
       body: body,
-      headers:{"X-Auth-Token" => auth_token}
+      headers: auth_header
     )
     ([201].include?(resp.response.code.to_i)) ||
       raise(StorageProviderException, resp.body)
   end
 
-  def put_object_manifest(container, object, manifest)
+  def put_object_manifest(container, object, manifest, content_type=nil, filename=nil)
+    content_headers = {}
+    if content_type
+      content_headers['content-type'] = content_type
+    end
+    if filename
+      content_headers['content-disposition'] = "attachment; filename=#{filename}"
+    end
     resp = HTTParty.put(
       "#{storage_url}/#{container}/#{object}?multipart-manifest=put",
       body: manifest.to_json,
-      headers:{"X-Auth-Token" => auth_token}
+      headers: auth_header.merge(content_headers)
     )
     ([201,202].include?(resp.response.code.to_i)) ||
       raise(StorageProviderException, resp.body)
@@ -111,7 +120,7 @@ class StorageProvider < ActiveRecord::Base
   def delete_object(container, object)
     resp = HTTParty.delete(
       "#{storage_url}/#{container}/#{object}?multipart-manifest=delete",
-      headers:{"X-Auth-Token" => auth_token}
+      headers: auth_header
     )
     ([200,204].include?(resp.response.code.to_i)) ||
       raise(StorageProviderException, resp.body)
@@ -120,7 +129,7 @@ class StorageProvider < ActiveRecord::Base
   def get_object_metadata(container, object)
     resp = HTTParty.head(
       "#{storage_url}/#{container}/#{object}",
-      headers:{"X-Auth-Token" => auth_token}
+      headers: auth_header
     )
     ([200,204].include?(resp.response.code.to_i)) ||
       raise(StorageProviderException, resp.body)

--- a/app/models/storage_provider.rb
+++ b/app/models/storage_provider.rb
@@ -102,7 +102,7 @@ class StorageProvider < ActiveRecord::Base
 
   def put_object_manifest(container, object, manifest, content_type=nil, filename=nil)
     content_headers = {}
-    if content_type
+    if content_type && !content_type.empty?
       content_headers['content-type'] = content_type
     end
     if filename

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -41,7 +41,7 @@ class Upload < ActiveRecord::Base
 
   def complete
     begin
-      response = storage_provider.put_object_manifest(project_id, id, manifest)
+      response = storage_provider.put_object_manifest(project_id, id, manifest, content_type, name)
       meta = storage_provider.get_object_metadata(project_id, id)
       unless meta["content-length"].to_i == size
         integrity_exception("reported size does not match size computed by StorageProvider")

--- a/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_a_storage_provider_backed_resource/should_return_a_500_error_and_JSON_error_when_a_StorageProviderException_is_experienced.yml
+++ b/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_a_storage_provider_backed_resource/should_return_a_500_error_and_JSON_error_when_a_StorageProviderException_is_experienced.yml
@@ -19,31 +19,31 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Length:
       - '0'
       X-Trans-Id:
-      - tx10204891a90144b6a639c-005671bc94
+      - txc9700d296b714f9ebc724-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:40 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/a6eaab13-197c-427e-9618-cb74b191dbe7
+    uri: http://192.168.99.100:12345/v1/AUTH_test/83b773c6-2acc-4e86-8a30-949dc60c015e
     body:
       encoding: UTF-8
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       X-Container-Meta-Access-Control-Allow-Origin:
       - "*"
   response:
@@ -56,30 +56,30 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx2d74bf76f5bc44fc81909-005671bc94
+      - tx031c2f7f4aa241f9a2ca1-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:40 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/a6eaab13-197c-427e-9618-cb74b191dbe7/74fe46ec-da4d-43fb-b2db-84cc90b106cc/1
+    uri: http://192.168.99.100:12345/v1/AUTH_test/83b773c6-2acc-4e86-8a30-949dc60c015e/ff4f210a-0e8a-439e-98a4-916075b67502/1
     body:
       encoding: UTF-8
       string: this is a chunk
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:41 GMT
+      - Fri, 08 Jan 2016 19:46:24 GMT
       Content-Length:
       - '0'
       Etag:
@@ -87,23 +87,23 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx19026e9806bc4e62ae5fa-005671bc94
+      - tx9632340590804494af39d-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:40 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 - request:
     method: delete
-    uri: http://192.168.99.100:12345/v1/AUTH_test/a6eaab13-197c-427e-9618-cb74b191dbe7/74fe46ec-da4d-43fb-b2db-84cc90b106cc/1?multipart-manifest=delete
+    uri: http://192.168.99.100:12345/v1/AUTH_test/83b773c6-2acc-4e86-8a30-949dc60c015e/ff4f210a-0e8a-439e-98a4-916075b67502/1?multipart-manifest=delete
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 200
@@ -112,16 +112,16 @@ http_interactions:
       Content-Type:
       - text/plain
       X-Trans-Id:
-      - txe54272920aa84ae1a64ec-005671bc94
+      - tx1320b4c49ee34750aae1e-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: "Number Deleted: 0\nNumber Not Found: 0\nResponse Body: \nResponse Status:
-        400 Bad Request\nErrors:\n/a6eaab13-197c-427e-9618-cb74b191dbe7/74fe46ec-da4d-43fb-b2db-84cc90b106cc/1,
+        400 Bad Request\nErrors:\n/83b773c6-2acc-4e86-8a30-949dc60c015e/ff4f210a-0e8a-439e-98a4-916075b67502/1,
         Not an SLO manifest"
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:40 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_a_storage_provider_backed_resource/should_return_an_error_if_the_reported_chunk_hash_does_not_match_storage_provider_computed_size.yml
+++ b/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_a_storage_provider_backed_resource/should_return_an_error_if_the_reported_chunk_hash_does_not_match_storage_provider_computed_size.yml
@@ -19,31 +19,31 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Length:
       - '0'
       X-Trans-Id:
-      - tx32cf6354d6dd4dabb0232-005671bc94
+      - tx4f93c16fbcab46e1a7ca0-0056901210
       Date:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:24 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:40 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:24 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/928bac01-a314-492d-9f62-6c539a2a4d26
+    uri: http://192.168.99.100:12345/v1/AUTH_test/7ac75525-f3ed-40f7-ab78-1ce949a1649a
     body:
       encoding: UTF-8
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       X-Container-Meta-Access-Control-Allow-Origin:
       - "*"
   response:
@@ -56,30 +56,30 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - txb5ea0bb9049646ccb4823-005671bc94
+      - txd6bb5a7be5dd47a29cdfe-0056901210
       Date:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:24 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:40 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:24 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/928bac01-a314-492d-9f62-6c539a2a4d26/2b5363fc-d525-4c38-b003-938e561d8cca/1
+    uri: http://192.168.99.100:12345/v1/AUTH_test/7ac75525-f3ed-40f7-ab78-1ce949a1649a/45548b03-8bae-4d1d-b3d3-d80d4a9a15d6/1
     body:
       encoding: UTF-8
       string: this is a chunk
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:41 GMT
+      - Fri, 08 Jan 2016 19:46:25 GMT
       Content-Length:
       - '0'
       Etag:
@@ -87,14 +87,14 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx3a8d8ee1b53846249e0e0-005671bc94
+      - txd8df7d52d47748c0a5e50-0056901210
       Date:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:24 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:40 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:24 GMT
 - request:
     method: get
     uri: http://192.168.99.100:12345/auth/v1.0
@@ -114,31 +114,35 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Length:
       - '0'
       X-Trans-Id:
-      - txc487926d3caa49e699b4a-005671bc94
+      - tx4498d380c282430ca3252-0056901210
       Date:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:24 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:40 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:24 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/928bac01-a314-492d-9f62-6c539a2a4d26/2b5363fc-d525-4c38-b003-938e561d8cca?multipart-manifest=put
+    uri: http://192.168.99.100:12345/v1/AUTH_test/7ac75525-f3ed-40f7-ab78-1ce949a1649a/45548b03-8bae-4d1d-b3d3-d80d4a9a15d6?multipart-manifest=put
     body:
       encoding: UTF-8
-      string: '[{"path":"928bac01-a314-492d-9f62-6c539a2a4d26/2b5363fc-d525-4c38-b003-938e561d8cca/1","etag":"NOTTHECOMPUTEDHASH","size_bytes":15}]'
+      string: '[{"path":"7ac75525-f3ed-40f7-ab78-1ce949a1649a/45548b03-8bae-4d1d-b3d3-d80d4a9a15d6/1","etag":"NOTTHECOMPUTEDHASH","size_bytes":15}]'
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
+      Content-Type:
+      - text/plain
+      Content-Disposition:
+      - attachment; filename=rerum.inventore
   response:
     status:
       code: 400
@@ -149,25 +153,25 @@ http_interactions:
       Content-Type:
       - text/plain
       X-Trans-Id:
-      - tx0fbce6e5b60540f2bd88b-005671bc94
+      - txcaf44996ff9b47db9cf21-0056901210
       Date:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:24 GMT
     body:
       encoding: UTF-8
       string: |-
         Errors:
-        928bac01-a314-492d-9f62-6c539a2a4d26/2b5363fc-d525-4c38-b003-938e561d8cca/1, Etag Mismatch
+        7ac75525-f3ed-40f7-ab78-1ce949a1649a/45548b03-8bae-4d1d-b3d3-d80d4a9a15d6/1, Etag Mismatch
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:40 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:24 GMT
 - request:
     method: delete
-    uri: http://192.168.99.100:12345/v1/AUTH_test/928bac01-a314-492d-9f62-6c539a2a4d26/2b5363fc-d525-4c38-b003-938e561d8cca/1?multipart-manifest=delete
+    uri: http://192.168.99.100:12345/v1/AUTH_test/7ac75525-f3ed-40f7-ab78-1ce949a1649a/45548b03-8bae-4d1d-b3d3-d80d4a9a15d6/1?multipart-manifest=delete
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 200
@@ -176,16 +180,16 @@ http_interactions:
       Content-Type:
       - text/plain
       X-Trans-Id:
-      - tx3feeff604dd64b80b0b09-005671bc94
+      - txe91e6149798b4ecb9253d-0056901210
       Date:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:24 GMT
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: "Number Deleted: 0\nNumber Not Found: 0\nResponse Body: \nResponse Status:
-        400 Bad Request\nErrors:\n/928bac01-a314-492d-9f62-6c539a2a4d26/2b5363fc-d525-4c38-b003-938e561d8cca/1,
+        400 Bad Request\nErrors:\n/7ac75525-f3ed-40f7-ab78-1ce949a1649a/45548b03-8bae-4d1d-b3d3-d80d4a9a15d6/1,
         Not an SLO manifest"
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:40 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:24 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_a_storage_provider_backed_resource/should_return_an_error_if_the_reported_size_does_not_match_storage_provider_computed_size.yml
+++ b/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_a_storage_provider_backed_resource/should_return_an_error_if_the_reported_size_does_not_match_storage_provider_computed_size.yml
@@ -19,31 +19,31 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Length:
       - '0'
       X-Trans-Id:
-      - tx2f357f96a2c04d7d8f1eb-005671bc94
+      - tx2ada11f24db741b98678d-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:40 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/60e5cd58-abcc-46c7-bbde-dcb66da0eec9
+    uri: http://192.168.99.100:12345/v1/AUTH_test/45459345-e61f-4fa4-a78a-5c5a92576ee5
     body:
       encoding: UTF-8
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       X-Container-Meta-Access-Control-Allow-Origin:
       - "*"
   response:
@@ -56,30 +56,30 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - txddc20915d1b843e689085-005671bc94
+      - tx0fdfa45b5df445449bf09-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:40 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/60e5cd58-abcc-46c7-bbde-dcb66da0eec9/644b6b9c-c0a6-4160-a906-e0dd5046affb/1
+    uri: http://192.168.99.100:12345/v1/AUTH_test/45459345-e61f-4fa4-a78a-5c5a92576ee5/d9e1bbec-3d40-4a46-b50b-aef609b86655/1
     body:
       encoding: UTF-8
       string: this is a chunk
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:41 GMT
+      - Fri, 08 Jan 2016 19:46:24 GMT
       Content-Length:
       - '0'
       Etag:
@@ -87,14 +87,14 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - txff65d66bd5c147e7ae215-005671bc94
+      - txc9df0f341e3f493fa6868-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:40 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 - request:
     method: get
     uri: http://192.168.99.100:12345/auth/v1.0
@@ -114,38 +114,42 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Length:
       - '0'
       X-Trans-Id:
-      - txcab786b283a240f5bfa11-005671bc94
+      - tx8866b92de39340729fb15-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:40 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/60e5cd58-abcc-46c7-bbde-dcb66da0eec9/644b6b9c-c0a6-4160-a906-e0dd5046affb?multipart-manifest=put
+    uri: http://192.168.99.100:12345/v1/AUTH_test/45459345-e61f-4fa4-a78a-5c5a92576ee5/d9e1bbec-3d40-4a46-b50b-aef609b86655?multipart-manifest=put
     body:
       encoding: UTF-8
-      string: '[{"path":"60e5cd58-abcc-46c7-bbde-dcb66da0eec9/644b6b9c-c0a6-4160-a906-e0dd5046affb/1","etag":"2b1f638751fa49d7fba5a64fecf48bb2","size_bytes":15}]'
+      string: '[{"path":"45459345-e61f-4fa4-a78a-5c5a92576ee5/d9e1bbec-3d40-4a46-b50b-aef609b86655/1","etag":"2b1f638751fa49d7fba5a64fecf48bb2","size_bytes":15}]'
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
+      Content-Type:
+      - text/plain
+      Content-Disposition:
+      - attachment; filename=est_sed
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:41 GMT
+      - Fri, 08 Jan 2016 19:46:24 GMT
       Content-Length:
       - '0'
       Etag:
@@ -153,23 +157,23 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx6e1b92157dd2412491f57-005671bc94
+      - txc4f30feb50604243b62bb-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:40 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 - request:
     method: head
-    uri: http://192.168.99.100:12345/v1/AUTH_test/60e5cd58-abcc-46c7-bbde-dcb66da0eec9/644b6b9c-c0a6-4160-a906-e0dd5046affb
+    uri: http://192.168.99.100:12345/v1/AUTH_test/45459345-e61f-4fa4-a78a-5c5a92576ee5/d9e1bbec-3d40-4a46-b50b-aef609b86655
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 200
@@ -177,36 +181,38 @@ http_interactions:
     headers:
       Content-Length:
       - '15'
+      Content-Disposition:
+      - attachment; filename=est_sed
       Accept-Ranges:
       - bytes
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:41 GMT
+      - Fri, 08 Jan 2016 19:46:24 GMT
       Etag:
       - '"b77622f6f760a1bed182840a7c02a53c"'
       X-Timestamp:
-      - '1450294420.52005'
+      - '1452282383.87557'
       X-Static-Large-Object:
       - 'True'
       Content-Type:
-      - application/x-www-form-urlencoded
+      - text/plain
       X-Trans-Id:
-      - tx63d1062bd9524e44aa5fa-005671bc94
+      - tx30d476787d254349baa1b-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:40 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 - request:
     method: delete
-    uri: http://192.168.99.100:12345/v1/AUTH_test/60e5cd58-abcc-46c7-bbde-dcb66da0eec9/644b6b9c-c0a6-4160-a906-e0dd5046affb/1?multipart-manifest=delete
+    uri: http://192.168.99.100:12345/v1/AUTH_test/45459345-e61f-4fa4-a78a-5c5a92576ee5/d9e1bbec-3d40-4a46-b50b-aef609b86655/1?multipart-manifest=delete
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 200
@@ -215,16 +221,16 @@ http_interactions:
       Content-Type:
       - text/plain
       X-Trans-Id:
-      - txbc5f6ed255a744d3bdd3d-005671bc94
+      - tx255aa842658e43619ea5d-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: "Number Deleted: 0\nNumber Not Found: 0\nResponse Body: \nResponse Status:
-        400 Bad Request\nErrors:\n/60e5cd58-abcc-46c7-bbde-dcb66da0eec9/644b6b9c-c0a6-4160-a906-e0dd5046affb/1,
+        400 Bad Request\nErrors:\n/45459345-e61f-4fa4-a78a-5c5a92576ee5/d9e1bbec-3d40-4a46-b50b-aef609b86655/1,
         Not an SLO manifest"
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:40 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_an_audited_endpoint/should_create_an_audit_for_an_audited_parent_with_the_current_user_as_user_and_url_as_audit_comment_if_with_audited_parent.yml
+++ b/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_an_audited_endpoint/should_create_an_audit_for_an_audited_parent_with_the_current_user_as_user_and_url_as_audit_comment_if_with_audited_parent.yml
@@ -19,31 +19,31 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Length:
       - '0'
       X-Trans-Id:
-      - txac2091d2437b49c1bb5bc-005671bc93
+      - txf2a2818243ae4f7fb806d-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:39 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/f08f32b8-a5e1-40fa-a8ea-e30017a5121d
+    uri: http://192.168.99.100:12345/v1/AUTH_test/7e5b47ea-351e-4c53-a0e6-dfb9c55aee11
     body:
       encoding: UTF-8
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       X-Container-Meta-Access-Control-Allow-Origin:
       - "*"
   response:
@@ -56,30 +56,30 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - txf6e67ea338bc4fb3ab86c-005671bc93
+      - txa9e1de5138da464c97404-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:39 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/f08f32b8-a5e1-40fa-a8ea-e30017a5121d/74466237-a903-48f5-b5f4-e31b43f65016/1
+    uri: http://192.168.99.100:12345/v1/AUTH_test/7e5b47ea-351e-4c53-a0e6-dfb9c55aee11/e1260dec-4d3b-4ed8-a94a-b9e29bf553c8/1
     body:
       encoding: UTF-8
       string: this is a chunk
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:24 GMT
       Content-Length:
       - '0'
       Etag:
@@ -87,23 +87,23 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx11a92ad7072b403fa49da-005671bc93
+      - txc20fb665b79b499ca23d4-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:39 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 - request:
     method: delete
-    uri: http://192.168.99.100:12345/v1/AUTH_test/f08f32b8-a5e1-40fa-a8ea-e30017a5121d/74466237-a903-48f5-b5f4-e31b43f65016/1?multipart-manifest=delete
+    uri: http://192.168.99.100:12345/v1/AUTH_test/7e5b47ea-351e-4c53-a0e6-dfb9c55aee11/e1260dec-4d3b-4ed8-a94a-b9e29bf553c8/1?multipart-manifest=delete
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 200
@@ -112,16 +112,16 @@ http_interactions:
       Content-Type:
       - text/plain
       X-Trans-Id:
-      - tx592e8ccdf83343fea73d8-005671bc93
+      - txe28cb127af614464820d2-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: "Number Deleted: 0\nNumber Not Found: 0\nResponse Body: \nResponse Status:
-        400 Bad Request\nErrors:\n/f08f32b8-a5e1-40fa-a8ea-e30017a5121d/74466237-a903-48f5-b5f4-e31b43f65016/1,
+        400 Bad Request\nErrors:\n/7e5b47ea-351e-4c53-a0e6-dfb9c55aee11/e1260dec-4d3b-4ed8-a94a-b9e29bf553c8/1,
         Not an SLO manifest"
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:39 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_an_audited_endpoint/should_create_an_audit_with_the_current_user_as_user_and_url_as_audit_comment.yml
+++ b/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_an_audited_endpoint/should_create_an_audit_with_the_current_user_as_user_and_url_as_audit_comment.yml
@@ -19,31 +19,31 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Length:
       - '0'
       X-Trans-Id:
-      - txf498a950d9e8406c9b072-005671bc93
+      - tx18821250014a4d689e710-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:39 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/a7c9890c-8232-4b94-b8eb-54baa2f49f3d
+    uri: http://192.168.99.100:12345/v1/AUTH_test/b490af41-ecb0-4bcd-b8d3-23358e42aa2f
     body:
       encoding: UTF-8
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       X-Container-Meta-Access-Control-Allow-Origin:
       - "*"
   response:
@@ -56,30 +56,30 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx9eb3cca1ac9445d2be647-005671bc93
+      - txa42a0a7e942a462882387-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:39 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/a7c9890c-8232-4b94-b8eb-54baa2f49f3d/5f429cae-00b0-4f89-98aa-72e71c2b383d/1
+    uri: http://192.168.99.100:12345/v1/AUTH_test/b490af41-ecb0-4bcd-b8d3-23358e42aa2f/5a3d0fca-1994-42c4-92d6-cd8ecb668ca9/1
     body:
       encoding: UTF-8
       string: this is a chunk
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:24 GMT
       Content-Length:
       - '0'
       Etag:
@@ -87,14 +87,14 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - txe8b3cfc69c724ea4998c0-005671bc93
+      - tx7696fe2e4d684b829c955-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:39 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 - request:
     method: get
     uri: http://192.168.99.100:12345/auth/v1.0
@@ -114,38 +114,42 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Length:
       - '0'
       X-Trans-Id:
-      - tx4010bb3343e7436ea1e03-005671bc93
+      - tx7d252ebfbf544df4b6596-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:39 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/a7c9890c-8232-4b94-b8eb-54baa2f49f3d/5f429cae-00b0-4f89-98aa-72e71c2b383d?multipart-manifest=put
+    uri: http://192.168.99.100:12345/v1/AUTH_test/b490af41-ecb0-4bcd-b8d3-23358e42aa2f/5a3d0fca-1994-42c4-92d6-cd8ecb668ca9?multipart-manifest=put
     body:
       encoding: UTF-8
-      string: '[{"path":"a7c9890c-8232-4b94-b8eb-54baa2f49f3d/5f429cae-00b0-4f89-98aa-72e71c2b383d/1","etag":"2b1f638751fa49d7fba5a64fecf48bb2","size_bytes":15}]'
+      string: '[{"path":"b490af41-ecb0-4bcd-b8d3-23358e42aa2f/5a3d0fca-1994-42c4-92d6-cd8ecb668ca9/1","etag":"2b1f638751fa49d7fba5a64fecf48bb2","size_bytes":15}]'
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
+      Content-Type:
+      - text/plain
+      Content-Disposition:
+      - attachment; filename=voluptas.odio
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:24 GMT
       Content-Length:
       - '0'
       Etag:
@@ -153,23 +157,23 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx9dc1c4a2f142463bbb634-005671bc93
+      - tx5482f70c82704c74a443b-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:39 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 - request:
     method: head
-    uri: http://192.168.99.100:12345/v1/AUTH_test/a7c9890c-8232-4b94-b8eb-54baa2f49f3d/5f429cae-00b0-4f89-98aa-72e71c2b383d
+    uri: http://192.168.99.100:12345/v1/AUTH_test/b490af41-ecb0-4bcd-b8d3-23358e42aa2f/5a3d0fca-1994-42c4-92d6-cd8ecb668ca9
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 200
@@ -177,36 +181,38 @@ http_interactions:
     headers:
       Content-Length:
       - '15'
+      Content-Disposition:
+      - attachment; filename=voluptas.odio
       Accept-Ranges:
       - bytes
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:24 GMT
       Etag:
       - '"b77622f6f760a1bed182840a7c02a53c"'
       X-Timestamp:
-      - '1450294419.67875'
+      - '1452282383.09460'
       X-Static-Large-Object:
       - 'True'
       Content-Type:
-      - application/x-www-form-urlencoded
+      - text/plain
       X-Trans-Id:
-      - tx44189be1395a42c5b5f53-005671bc93
+      - tx27e5d670d38441f98e09a-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:39 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 - request:
     method: delete
-    uri: http://192.168.99.100:12345/v1/AUTH_test/a7c9890c-8232-4b94-b8eb-54baa2f49f3d/5f429cae-00b0-4f89-98aa-72e71c2b383d/1?multipart-manifest=delete
+    uri: http://192.168.99.100:12345/v1/AUTH_test/b490af41-ecb0-4bcd-b8d3-23358e42aa2f/5a3d0fca-1994-42c4-92d6-cd8ecb668ca9/1?multipart-manifest=delete
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 200
@@ -215,16 +221,16 @@ http_interactions:
       Content-Type:
       - text/plain
       X-Trans-Id:
-      - txfaba09dffeff428db18da-005671bc93
+      - tx6ff42b4a747e4df3ad1f3-005690120f
       Date:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: "Number Deleted: 0\nNumber Not Found: 0\nResponse Body: \nResponse Status:
-        400 Bad Request\nErrors:\n/a7c9890c-8232-4b94-b8eb-54baa2f49f3d/5f429cae-00b0-4f89-98aa-72e71c2b383d/1,
+        400 Bad Request\nErrors:\n/b490af41-ecb0-4bcd-b8d3-23358e42aa2f/5a3d0fca-1994-42c4-92d6-cd8ecb668ca9/1,
         Not an SLO manifest"
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:39 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:23 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_an_authenticated_resource/should_return_a_401_error_response.yml
+++ b/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_an_authenticated_resource/should_return_a_401_error_response.yml
@@ -19,31 +19,31 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Length:
       - '0'
       X-Trans-Id:
-      - tx1544d54df7b64672856d7-005671bc92
+      - txfe12c91dca7f45c68c4a4-005690120e
       Date:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:38 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:22 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/42550c96-1124-484f-8806-7f6a586106e4
+    uri: http://192.168.99.100:12345/v1/AUTH_test/53730fa5-e403-418c-ac49-010b751cf771
     body:
       encoding: UTF-8
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       X-Container-Meta-Access-Control-Allow-Origin:
       - "*"
   response:
@@ -56,30 +56,30 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx69a19dc961384b87ae8a5-005671bc92
+      - tx3f798c4d3792421b896f6-005690120e
       Date:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:38 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:22 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/42550c96-1124-484f-8806-7f6a586106e4/d6510afb-092a-4540-ad78-3aa6ff20b5d4/1
+    uri: http://192.168.99.100:12345/v1/AUTH_test/53730fa5-e403-418c-ac49-010b751cf771/34bb1513-1013-4537-98ab-af19347f6e5b/1
     body:
       encoding: UTF-8
       string: this is a chunk
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
       Content-Length:
       - '0'
       Etag:
@@ -87,23 +87,23 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx22abf30294654a8e9b3ff-005671bc92
+      - txeb41321ac7be4f74abf49-005690120e
       Date:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:38 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:22 GMT
 - request:
     method: delete
-    uri: http://192.168.99.100:12345/v1/AUTH_test/42550c96-1124-484f-8806-7f6a586106e4/d6510afb-092a-4540-ad78-3aa6ff20b5d4/1?multipart-manifest=delete
+    uri: http://192.168.99.100:12345/v1/AUTH_test/53730fa5-e403-418c-ac49-010b751cf771/34bb1513-1013-4537-98ab-af19347f6e5b/1?multipart-manifest=delete
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 200
@@ -112,16 +112,16 @@ http_interactions:
       Content-Type:
       - text/plain
       X-Trans-Id:
-      - tx40124ee58b3940a584c4e-005671bc92
+      - tx2f423342c9db467889eda-005690120e
       Date:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: "Number Deleted: 0\nNumber Not Found: 0\nResponse Body: \nResponse Status:
-        400 Bad Request\nErrors:\n/42550c96-1124-484f-8806-7f6a586106e4/d6510afb-092a-4540-ad78-3aa6ff20b5d4/1,
+        400 Bad Request\nErrors:\n/53730fa5-e403-418c-ac49-010b751cf771/34bb1513-1013-4537-98ab-af19347f6e5b/1,
         Not an SLO manifest"
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:38 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:22 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_an_authorized_resource/should_return_a_403_error_response.yml
+++ b/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_an_authorized_resource/should_return_a_403_error_response.yml
@@ -19,31 +19,31 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Length:
       - '0'
       X-Trans-Id:
-      - tx135aeeec920347d4a626c-005671bc93
+      - txcd33e33abe624fb5bcc7d-005690120e
       Date:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:39 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:22 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/7b766f4a-3957-41a6-b74f-29c2aba2ef14
+    uri: http://192.168.99.100:12345/v1/AUTH_test/e8baa6c1-d41a-4aa4-b829-f409b70785f3
     body:
       encoding: UTF-8
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       X-Container-Meta-Access-Control-Allow-Origin:
       - "*"
   response:
@@ -56,30 +56,30 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx02c2a1788a0a4e869893f-005671bc93
+      - txb2ec56d77cf943ba925a0-005690120e
       Date:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:39 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:22 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/7b766f4a-3957-41a6-b74f-29c2aba2ef14/7a7eb8e6-9baa-49a6-a529-3728184c9a49/1
+    uri: http://192.168.99.100:12345/v1/AUTH_test/e8baa6c1-d41a-4aa4-b829-f409b70785f3/736871ee-44e1-4843-9711-6a9a15fb4c2b/1
     body:
       encoding: UTF-8
       string: this is a chunk
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
       Content-Length:
       - '0'
       Etag:
@@ -87,23 +87,23 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx8153abc6990d4096bb033-005671bc93
+      - txe5f06ef0853c46d486243-005690120e
       Date:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:39 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:22 GMT
 - request:
     method: delete
-    uri: http://192.168.99.100:12345/v1/AUTH_test/7b766f4a-3957-41a6-b74f-29c2aba2ef14/7a7eb8e6-9baa-49a6-a529-3728184c9a49/1?multipart-manifest=delete
+    uri: http://192.168.99.100:12345/v1/AUTH_test/e8baa6c1-d41a-4aa4-b829-f409b70785f3/736871ee-44e1-4843-9711-6a9a15fb4c2b/1?multipart-manifest=delete
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 200
@@ -112,16 +112,16 @@ http_interactions:
       Content-Type:
       - text/plain
       X-Trans-Id:
-      - tx1655b1badf694f399540e-005671bc93
+      - tx295e8ad5247e482899dd8-005690120e
       Date:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: "Number Deleted: 0\nNumber Not Found: 0\nResponse Body: \nResponse Status:
-        400 Bad Request\nErrors:\n/7b766f4a-3957-41a6-b74f-29c2aba2ef14/7a7eb8e6-9baa-49a6-a529-3728184c9a49/1,
+        400 Bad Request\nErrors:\n/e8baa6c1-d41a-4aa4-b829-f409b70785f3/736871ee-44e1-4843-9711-6a9a15fb4c2b/1,
         Not an SLO manifest"
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:39 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:22 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_an_identified_resource/should_return_404_with_error_when_resource_not_found_with_id.yml
+++ b/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_an_identified_resource/should_return_404_with_error_when_resource_not_found_with_id.yml
@@ -19,31 +19,31 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Length:
       - '0'
       X-Trans-Id:
-      - txd0828731f91549d08595a-005671bc93
+      - tx0bd13f7509074eab9e1d6-005690120e
       Date:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:39 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:22 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/6a417f2a-426d-4f2f-a530-1da44aac4685
+    uri: http://192.168.99.100:12345/v1/AUTH_test/7207f716-e1ab-40dc-a675-91787f503711
     body:
       encoding: UTF-8
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       X-Container-Meta-Access-Control-Allow-Origin:
       - "*"
   response:
@@ -56,30 +56,30 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx89b49099edf34f2b9caf1-005671bc93
+      - tx3a5f28c6117241c5beb8d-005690120e
       Date:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:39 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:22 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/6a417f2a-426d-4f2f-a530-1da44aac4685/942a2f3c-bb3f-4266-8226-348792c1462d/1
+    uri: http://192.168.99.100:12345/v1/AUTH_test/7207f716-e1ab-40dc-a675-91787f503711/cce1d41b-c703-424c-87ce-d0ac690813a5/1
     body:
       encoding: UTF-8
       string: this is a chunk
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:40 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
       Content-Length:
       - '0'
       Etag:
@@ -87,23 +87,23 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - txc91df37a71bc4f31bf949-005671bc93
+      - txf7e51824173b4fd39431c-005690120e
       Date:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:39 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:22 GMT
 - request:
     method: delete
-    uri: http://192.168.99.100:12345/v1/AUTH_test/6a417f2a-426d-4f2f-a530-1da44aac4685/942a2f3c-bb3f-4266-8226-348792c1462d/1?multipart-manifest=delete
+    uri: http://192.168.99.100:12345/v1/AUTH_test/7207f716-e1ab-40dc-a675-91787f503711/cce1d41b-c703-424c-87ce-d0ac690813a5/1?multipart-manifest=delete
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 200
@@ -112,16 +112,16 @@ http_interactions:
       Content-Type:
       - text/plain
       X-Trans-Id:
-      - txd33c218cb78045fa8d722-005671bc93
+      - txcaa5f361838e413bb3bcc-005690120e
       Date:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: "Number Deleted: 0\nNumber Not Found: 0\nResponse Body: \nResponse Status:
-        400 Bad Request\nErrors:\n/6a417f2a-426d-4f2f-a530-1da44aac4685/942a2f3c-bb3f-4266-8226-348792c1462d/1,
+        400 Bad Request\nErrors:\n/7207f716-e1ab-40dc-a675-91787f503711/cce1d41b-c703-424c-87ce-d0ac690813a5/1,
         Not an SLO manifest"
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:39 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:22 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_an_updatable_resource/should_persist_changes_to_resource.yml
+++ b/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_an_updatable_resource/should_persist_changes_to_resource.yml
@@ -19,31 +19,31 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Length:
       - '0'
       X-Trans-Id:
-      - txb7bb760669ee4fce9f21a-005671bc92
+      - tx4f05771074eb41e0b7f6f-005690120d
       Date:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:21 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:38 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:21 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/774959e0-4bbe-43c4-be83-531f42d99ec1
+    uri: http://192.168.99.100:12345/v1/AUTH_test/e0438b67-c7fe-4a9f-b365-1d87472e4e83
     body:
       encoding: UTF-8
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       X-Container-Meta-Access-Control-Allow-Origin:
       - "*"
   response:
@@ -56,30 +56,30 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx2dd633597cd043a4b8fea-005671bc92
+      - txe0735310cc3e4fe18e5ef-005690120d
       Date:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:21 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:38 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:21 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/774959e0-4bbe-43c4-be83-531f42d99ec1/bb3358b3-854f-44cd-82bc-a14ab5c3f894/1
+    uri: http://192.168.99.100:12345/v1/AUTH_test/e0438b67-c7fe-4a9f-b365-1d87472e4e83/0db677f4-9d0d-4491-9569-078ed18ff924/1
     body:
       encoding: UTF-8
       string: this is a chunk
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
       Content-Length:
       - '0'
       Etag:
@@ -87,14 +87,14 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - txf9351cbd226a427eb2b49-005671bc92
+      - txb4c941525e874b32a4b3b-005690120d
       Date:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:21 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:38 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:21 GMT
 - request:
     method: get
     uri: http://192.168.99.100:12345/auth/v1.0
@@ -114,38 +114,42 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Length:
       - '0'
       X-Trans-Id:
-      - tx1c4a98961a084647a80a6-005671bc92
+      - tx778ce4718ebd46368c567-005690120d
       Date:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:21 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:38 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:21 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/774959e0-4bbe-43c4-be83-531f42d99ec1/bb3358b3-854f-44cd-82bc-a14ab5c3f894?multipart-manifest=put
+    uri: http://192.168.99.100:12345/v1/AUTH_test/e0438b67-c7fe-4a9f-b365-1d87472e4e83/0db677f4-9d0d-4491-9569-078ed18ff924?multipart-manifest=put
     body:
       encoding: UTF-8
-      string: '[{"path":"774959e0-4bbe-43c4-be83-531f42d99ec1/bb3358b3-854f-44cd-82bc-a14ab5c3f894/1","etag":"2b1f638751fa49d7fba5a64fecf48bb2","size_bytes":15}]'
+      string: '[{"path":"e0438b67-c7fe-4a9f-b365-1d87472e4e83/0db677f4-9d0d-4491-9569-078ed18ff924/1","etag":"2b1f638751fa49d7fba5a64fecf48bb2","size_bytes":15}]'
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
+      Content-Type:
+      - text/plain
+      Content-Disposition:
+      - attachment; filename=blanditiis-consequatur
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
       Content-Length:
       - '0'
       Etag:
@@ -153,23 +157,23 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx22ab344dff3a476eb50e6-005671bc92
+      - tx209951e026294d7f8ed60-005690120d
       Date:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:21 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:38 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:21 GMT
 - request:
     method: head
-    uri: http://192.168.99.100:12345/v1/AUTH_test/774959e0-4bbe-43c4-be83-531f42d99ec1/bb3358b3-854f-44cd-82bc-a14ab5c3f894
+    uri: http://192.168.99.100:12345/v1/AUTH_test/e0438b67-c7fe-4a9f-b365-1d87472e4e83/0db677f4-9d0d-4491-9569-078ed18ff924
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 200
@@ -177,36 +181,38 @@ http_interactions:
     headers:
       Content-Length:
       - '15'
+      Content-Disposition:
+      - attachment; filename=blanditiis-consequatur
       Accept-Ranges:
       - bytes
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
       Etag:
       - '"b77622f6f760a1bed182840a7c02a53c"'
       X-Timestamp:
-      - '1450294418.28913'
+      - '1452282381.77409'
       X-Static-Large-Object:
       - 'True'
       Content-Type:
-      - application/x-www-form-urlencoded
+      - text/plain
       X-Trans-Id:
-      - tx499dfa280128447a95578-005671bc92
+      - tx77204d8dd4dc42bda381b-005690120d
       Date:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:21 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:38 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:21 GMT
 - request:
     method: delete
-    uri: http://192.168.99.100:12345/v1/AUTH_test/774959e0-4bbe-43c4-be83-531f42d99ec1/bb3358b3-854f-44cd-82bc-a14ab5c3f894/1?multipart-manifest=delete
+    uri: http://192.168.99.100:12345/v1/AUTH_test/e0438b67-c7fe-4a9f-b365-1d87472e4e83/0db677f4-9d0d-4491-9569-078ed18ff924/1?multipart-manifest=delete
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 200
@@ -215,16 +221,16 @@ http_interactions:
       Content-Type:
       - text/plain
       X-Trans-Id:
-      - txf415ba3d6f15448893610-005671bc92
+      - tx411274a9cb7142e4b1c96-005690120d
       Date:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:21 GMT
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: "Number Deleted: 0\nNumber Not Found: 0\nResponse Body: \nResponse Status:
-        400 Bad Request\nErrors:\n/774959e0-4bbe-43c4-be83-531f42d99ec1/bb3358b3-854f-44cd-82bc-a14ab5c3f894/1,
+        400 Bad Request\nErrors:\n/e0438b67-c7fe-4a9f-b365-1d87472e4e83/0db677f4-9d0d-4491-9569-078ed18ff924/1,
         Not an SLO manifest"
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:38 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:21 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_an_updatable_resource/should_return_a_serialized_resource.yml
+++ b/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_an_updatable_resource/should_return_a_serialized_resource.yml
@@ -19,31 +19,31 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Length:
       - '0'
       X-Trans-Id:
-      - txcbda7eb691d648d5a005d-005671bc92
+      - tx38b549bb2c2a499ca7267-005690120d
       Date:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:21 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:38 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:21 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/b3d065aa-4089-4e08-bc06-b14841e4b0c9
+    uri: http://192.168.99.100:12345/v1/AUTH_test/1bbea3fe-f1b6-46b3-9f2d-20e6dc09de90
     body:
       encoding: UTF-8
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       X-Container-Meta-Access-Control-Allow-Origin:
       - "*"
   response:
@@ -56,30 +56,30 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx3533bd71b2294534ab17f-005671bc92
+      - txb3e9c43d175e443b91b30-005690120d
       Date:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:21 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:38 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:21 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/b3d065aa-4089-4e08-bc06-b14841e4b0c9/e339dc02-1527-4359-903a-956df8adace1/1
+    uri: http://192.168.99.100:12345/v1/AUTH_test/1bbea3fe-f1b6-46b3-9f2d-20e6dc09de90/6908ea44-705c-47a3-a903-a51f880deaed/1
     body:
       encoding: UTF-8
       string: this is a chunk
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
       Content-Length:
       - '0'
       Etag:
@@ -87,14 +87,14 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx49d791921e0e4122b1397-005671bc92
+      - txd98c89e2d617455da6640-005690120d
       Date:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:21 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:38 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:21 GMT
 - request:
     method: get
     uri: http://192.168.99.100:12345/auth/v1.0
@@ -114,38 +114,42 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Length:
       - '0'
       X-Trans-Id:
-      - tx3f137a520b084cd392bf7-005671bc92
+      - tx0f062b46300742c5a102c-005690120e
       Date:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:38 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:22 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/b3d065aa-4089-4e08-bc06-b14841e4b0c9/e339dc02-1527-4359-903a-956df8adace1?multipart-manifest=put
+    uri: http://192.168.99.100:12345/v1/AUTH_test/1bbea3fe-f1b6-46b3-9f2d-20e6dc09de90/6908ea44-705c-47a3-a903-a51f880deaed?multipart-manifest=put
     body:
       encoding: UTF-8
-      string: '[{"path":"b3d065aa-4089-4e08-bc06-b14841e4b0c9/e339dc02-1527-4359-903a-956df8adace1/1","etag":"2b1f638751fa49d7fba5a64fecf48bb2","size_bytes":15}]'
+      string: '[{"path":"1bbea3fe-f1b6-46b3-9f2d-20e6dc09de90/6908ea44-705c-47a3-a903-a51f880deaed/1","etag":"2b1f638751fa49d7fba5a64fecf48bb2","size_bytes":15}]'
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
+      Content-Type:
+      - text/plain
+      Content-Disposition:
+      - attachment; filename=impedit_necessitatibus
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
       Content-Length:
       - '0'
       Etag:
@@ -153,23 +157,23 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx00260aa87df7497aaf4bf-005671bc92
+      - tx2f20b5aabb594c3f8802d-005690120e
       Date:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:38 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:22 GMT
 - request:
     method: head
-    uri: http://192.168.99.100:12345/v1/AUTH_test/b3d065aa-4089-4e08-bc06-b14841e4b0c9/e339dc02-1527-4359-903a-956df8adace1
+    uri: http://192.168.99.100:12345/v1/AUTH_test/1bbea3fe-f1b6-46b3-9f2d-20e6dc09de90/6908ea44-705c-47a3-a903-a51f880deaed
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 200
@@ -177,36 +181,38 @@ http_interactions:
     headers:
       Content-Length:
       - '15'
+      Content-Disposition:
+      - attachment; filename=impedit_necessitatibus
       Accept-Ranges:
       - bytes
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:39 GMT
+      - Fri, 08 Jan 2016 19:46:23 GMT
       Etag:
       - '"b77622f6f760a1bed182840a7c02a53c"'
       X-Timestamp:
-      - '1450294418.60554'
+      - '1452282382.06767'
       X-Static-Large-Object:
       - 'True'
       Content-Type:
-      - application/x-www-form-urlencoded
+      - text/plain
       X-Trans-Id:
-      - txc41a62caeb3e42daacd3f-005671bc92
+      - tx44b945b64e7e44feaccb4-005690120e
       Date:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:38 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:22 GMT
 - request:
     method: delete
-    uri: http://192.168.99.100:12345/v1/AUTH_test/b3d065aa-4089-4e08-bc06-b14841e4b0c9/e339dc02-1527-4359-903a-956df8adace1/1?multipart-manifest=delete
+    uri: http://192.168.99.100:12345/v1/AUTH_test/1bbea3fe-f1b6-46b3-9f2d-20e6dc09de90/6908ea44-705c-47a3-a903-a51f880deaed/1?multipart-manifest=delete
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 200
@@ -215,16 +221,16 @@ http_interactions:
       Content-Type:
       - text/plain
       X-Trans-Id:
-      - tx656587db4ad64e1fa5d16-005671bc92
+      - txe35bd54ee82340f5a7d6a-005690120e
       Date:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: "Number Deleted: 0\nNumber Not Found: 0\nResponse Body: \nResponse Status:
-        400 Bad Request\nErrors:\n/b3d065aa-4089-4e08-bc06-b14841e4b0c9/e339dc02-1527-4359-903a-956df8adace1/1,
+        400 Bad Request\nErrors:\n/1bbea3fe-f1b6-46b3-9f2d-20e6dc09de90/6908ea44-705c-47a3-a903-a51f880deaed/1,
         Not an SLO manifest"
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:38 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:22 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_an_updatable_resource/should_return_success.yml
+++ b/spec/cassettes/DDS_V1_UploadsAPI/Complete_the_chunked_file_upload/behaves_like_an_updatable_resource/should_return_success.yml
@@ -19,31 +19,31 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Length:
       - '0'
       X-Trans-Id:
-      - txc2a02677709448af9f2ad-005671bc91
+      - tx9e6030470f1c40859ea30-005690120d
       Date:
-      - Wed, 16 Dec 2015 19:33:37 GMT
+      - Fri, 08 Jan 2016 19:46:21 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:37 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:21 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/6f62ab5b-0b3e-4e83-87b5-519ec962cb90
+    uri: http://192.168.99.100:12345/v1/AUTH_test/1f3ad885-ea71-4c76-b815-6755daa7a268
     body:
       encoding: UTF-8
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       X-Container-Meta-Access-Control-Allow-Origin:
       - "*"
   response:
@@ -56,30 +56,30 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - txefd7ee034fbc44e083a17-005671bc91
+      - tx9eab1ee15a4747a99faaa-005690120d
       Date:
-      - Wed, 16 Dec 2015 19:33:37 GMT
+      - Fri, 08 Jan 2016 19:46:21 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:37 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:21 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/6f62ab5b-0b3e-4e83-87b5-519ec962cb90/04bce87a-a05e-4c3b-a88f-4f191afa7237/1
+    uri: http://192.168.99.100:12345/v1/AUTH_test/1f3ad885-ea71-4c76-b815-6755daa7a268/f1fcff57-a8ec-40dd-9e26-dbaefdd4fb41/1
     body:
       encoding: UTF-8
       string: this is a chunk
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
       Content-Length:
       - '0'
       Etag:
@@ -87,14 +87,14 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx4527986698ac499e9ca2a-005671bc91
+      - txbc3be2365d344d6f894bf-005690120d
       Date:
-      - Wed, 16 Dec 2015 19:33:37 GMT
+      - Fri, 08 Jan 2016 19:46:21 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:37 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:21 GMT
 - request:
     method: get
     uri: http://192.168.99.100:12345/auth/v1.0
@@ -114,38 +114,42 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
       Content-Length:
       - '0'
       X-Trans-Id:
-      - tx5f9d488c522845d8bb43b-005671bc91
+      - tx9df5d8f418c949fe8d550-005690120d
       Date:
-      - Wed, 16 Dec 2015 19:33:37 GMT
+      - Fri, 08 Jan 2016 19:46:21 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:37 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:21 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/6f62ab5b-0b3e-4e83-87b5-519ec962cb90/04bce87a-a05e-4c3b-a88f-4f191afa7237?multipart-manifest=put
+    uri: http://192.168.99.100:12345/v1/AUTH_test/1f3ad885-ea71-4c76-b815-6755daa7a268/f1fcff57-a8ec-40dd-9e26-dbaefdd4fb41?multipart-manifest=put
     body:
       encoding: UTF-8
-      string: '[{"path":"6f62ab5b-0b3e-4e83-87b5-519ec962cb90/04bce87a-a05e-4c3b-a88f-4f191afa7237/1","etag":"2b1f638751fa49d7fba5a64fecf48bb2","size_bytes":15}]'
+      string: '[{"path":"1f3ad885-ea71-4c76-b815-6755daa7a268/f1fcff57-a8ec-40dd-9e26-dbaefdd4fb41/1","etag":"2b1f638751fa49d7fba5a64fecf48bb2","size_bytes":15}]'
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
+      Content-Type:
+      - text/plain
+      Content-Disposition:
+      - attachment; filename=omnis-non
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
       Content-Length:
       - '0'
       Etag:
@@ -153,23 +157,23 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx9061cdfbf60d40ce8e267-005671bc91
+      - txb7db0b7bd15b4c83890b5-005690120d
       Date:
-      - Wed, 16 Dec 2015 19:33:37 GMT
+      - Fri, 08 Jan 2016 19:46:21 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:37 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:21 GMT
 - request:
     method: head
-    uri: http://192.168.99.100:12345/v1/AUTH_test/6f62ab5b-0b3e-4e83-87b5-519ec962cb90/04bce87a-a05e-4c3b-a88f-4f191afa7237
+    uri: http://192.168.99.100:12345/v1/AUTH_test/1f3ad885-ea71-4c76-b815-6755daa7a268/f1fcff57-a8ec-40dd-9e26-dbaefdd4fb41
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 200
@@ -177,36 +181,38 @@ http_interactions:
     headers:
       Content-Length:
       - '15'
+      Content-Disposition:
+      - attachment; filename=omnis-non
       Accept-Ranges:
       - bytes
       Last-Modified:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:22 GMT
       Etag:
       - '"b77622f6f760a1bed182840a7c02a53c"'
       X-Timestamp:
-      - '1450294417.95980'
+      - '1452282381.49738'
       X-Static-Large-Object:
       - 'True'
       Content-Type:
-      - application/x-www-form-urlencoded
+      - text/plain
       X-Trans-Id:
-      - txaba2403f83774b97ac484-005671bc91
+      - tx7fa70e1db93a4c7eb7253-005690120d
       Date:
-      - Wed, 16 Dec 2015 19:33:37 GMT
+      - Fri, 08 Jan 2016 19:46:21 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:37 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:21 GMT
 - request:
     method: delete
-    uri: http://192.168.99.100:12345/v1/AUTH_test/6f62ab5b-0b3e-4e83-87b5-519ec962cb90/04bce87a-a05e-4c3b-a88f-4f191afa7237/1?multipart-manifest=delete
+    uri: http://192.168.99.100:12345/v1/AUTH_test/1f3ad885-ea71-4c76-b815-6755daa7a268/f1fcff57-a8ec-40dd-9e26-dbaefdd4fb41/1?multipart-manifest=delete
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tk7b880f82ecdf4bc28f40338691253570
   response:
     status:
       code: 200
@@ -215,16 +221,16 @@ http_interactions:
       Content-Type:
       - text/plain
       X-Trans-Id:
-      - tx2d060dda1c6a454483818-005671bc92
+      - tx10fd548792da4109988f2-005690120d
       Date:
-      - Wed, 16 Dec 2015 19:33:38 GMT
+      - Fri, 08 Jan 2016 19:46:21 GMT
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: "Number Deleted: 0\nNumber Not Found: 0\nResponse Body: \nResponse Status:
-        400 Bad Request\nErrors:\n/6f62ab5b-0b3e-4e83-87b5-519ec962cb90/04bce87a-a05e-4c3b-a88f-4f191afa7237/1,
+        400 Bad Request\nErrors:\n/1f3ad885-ea71-4c76-b815-6755daa7a268/f1fcff57-a8ec-40dd-9e26-dbaefdd4fb41/1,
         Not an SLO manifest"
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:33:38 GMT
+  recorded_at: Fri, 08 Jan 2016 19:46:21 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_respond_to_auth_header.yml
+++ b/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_respond_to_auth_header.yml
@@ -27,7 +27,7 @@ http_interactions:
       Content-Length:
       - '0'
       X-Trans-Id:
-      - tx4144ba54c4f74c8ea3d5a-0056900b79
+      - tx90e61448459949fc8d13e-0056900b79
       Date:
       - Fri, 08 Jan 2016 19:18:17 GMT
     body:

--- a/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_respond_to_delete_container.yml
+++ b/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_respond_to_delete_container.yml
@@ -19,22 +19,22 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       Content-Length:
       - '0'
       X-Trans-Id:
-      - tx540eb81b74fe4e48b1613-005671bc2c
+      - tx551e8118d7bd465c86212-0056900b79
       Date:
-      - Wed, 16 Dec 2015 19:31:56 GMT
+      - Fri, 08 Jan 2016 19:18:17 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:31:56 GMT
+  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 - request:
     method: delete
     uri: http://192.168.99.100:12345/v1/AUTH_test/the_container
@@ -43,7 +43,7 @@ http_interactions:
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
   response:
     status:
       code: 204
@@ -54,12 +54,12 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx44c4ee48892744b8ade1f-005671bc2c
+      - tx4a7d3277852346ea96259-0056900b79
       Date:
-      - Wed, 16 Dec 2015 19:31:56 GMT
+      - Fri, 08 Jan 2016 19:18:17 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:31:56 GMT
+  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_respond_to_delete_object.yml
+++ b/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_respond_to_delete_object.yml
@@ -19,22 +19,22 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       Content-Length:
       - '0'
       X-Trans-Id:
-      - tx7f018a6592474fd899476-005671bc2c
+      - tx7efb3cf393c743c2908cd-0056900b79
       Date:
-      - Wed, 16 Dec 2015 19:31:56 GMT
+      - Fri, 08 Jan 2016 19:18:17 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:31:56 GMT
+  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 - request:
     method: delete
     uri: http://192.168.99.100:12345/v1/AUTH_test/the_container/the_object?multipart-manifest=delete
@@ -43,7 +43,7 @@ http_interactions:
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
   response:
     status:
       code: 200
@@ -52,9 +52,9 @@ http_interactions:
       Content-Type:
       - text/plain
       X-Trans-Id:
-      - tx59fb6bce8c104becb15ac-005671bc2c
+      - tx0abb755054b948cc86dfe-0056900b79
       Date:
-      - Wed, 16 Dec 2015 19:31:56 GMT
+      - Fri, 08 Jan 2016 19:18:17 GMT
       Transfer-Encoding:
       - chunked
     body:
@@ -62,5 +62,5 @@ http_interactions:
       string: "Number Deleted: 2\nNumber Not Found: 0\nResponse Body: \nResponse Status:
         200 OK\nErrors:\n"
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:31:56 GMT
+  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_respond_to_get_account_info.yml
+++ b/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_respond_to_get_account_info.yml
@@ -19,22 +19,22 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       Content-Length:
       - '0'
       X-Trans-Id:
-      - txeab46c2dffd0416e9d8ab-005671bc2c
+      - tx8b09852c901942ad93f51-0056900b79
       Date:
-      - Wed, 16 Dec 2015 19:31:56 GMT
+      - Fri, 08 Jan 2016 19:18:17 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:31:56 GMT
+  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 - request:
     method: get
     uri: http://192.168.99.100:12345/v1/AUTH_test
@@ -43,7 +43,7 @@ http_interactions:
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
   response:
     status:
       code: 204
@@ -54,22 +54,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1450294316.19272'
+      - '1452280697.10353'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1450294316.19272'
+      - '1452280697.10353'
       Content-Length:
       - '0'
       X-Trans-Id:
-      - txbdd461e4fb44492095499-005671bc2c
+      - txb9bd8f15b23443bbbe261-0056900b79
       Date:
-      - Wed, 16 Dec 2015 19:31:56 GMT
+      - Fri, 08 Jan 2016 19:18:17 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:31:56 GMT
+  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_respond_to_put_container.yml
+++ b/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_respond_to_put_container.yml
@@ -19,22 +19,22 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       Content-Length:
       - '0'
       X-Trans-Id:
-      - tx5d311d11ce734ebdbaf79-005671bc2c
+      - tx0fc9daa2583a40d39d5cd-0056900b79
       Date:
-      - Wed, 16 Dec 2015 19:31:56 GMT
+      - Fri, 08 Jan 2016 19:18:17 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:31:56 GMT
+  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 - request:
     method: put
     uri: http://192.168.99.100:12345/v1/AUTH_test/the_container
@@ -43,7 +43,7 @@ http_interactions:
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       X-Container-Meta-Access-Control-Allow-Origin:
       - "*"
   response:
@@ -56,12 +56,12 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - txb373cfe54f23448a83606-005671bc2c
+      - txfd827a74b63049e8b06d7-0056900b79
       Date:
-      - Wed, 16 Dec 2015 19:31:56 GMT
+      - Fri, 08 Jan 2016 19:18:17 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:31:56 GMT
+  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_respond_to_put_object.yml
+++ b/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_respond_to_put_object.yml
@@ -19,22 +19,22 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       Content-Length:
       - '0'
       X-Trans-Id:
-      - tx4ab6f1974a1c421f83bd1-005671bc2c
+      - tx0699246c4f514d8d85f09-0056900b79
       Date:
-      - Wed, 16 Dec 2015 19:31:56 GMT
+      - Fri, 08 Jan 2016 19:18:17 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:31:56 GMT
+  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 - request:
     method: put
     uri: http://192.168.99.100:12345/v1/AUTH_test/the_container/the_object/1
@@ -43,14 +43,14 @@ http_interactions:
       string: This is the object body!
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:31:57 GMT
+      - Fri, 08 Jan 2016 19:18:18 GMT
       Content-Length:
       - '0'
       Etag:
@@ -58,12 +58,12 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx0b07de2044504fda97932-005671bc2c
+      - tx944a8435fe1e466e86537-0056900b79
       Date:
-      - Wed, 16 Dec 2015 19:31:56 GMT
+      - Fri, 08 Jan 2016 19:18:17 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:31:56 GMT
+  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_respond_to_put_object_manifest.yml
+++ b/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_respond_to_put_object_manifest.yml
@@ -19,22 +19,22 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       Content-Length:
       - '0'
       X-Trans-Id:
-      - tx72e2cf269a9f41c09aaca-005671bc2c
+      - tx60fa4a3bd1914db3a4ff4-0056900b79
       Date:
-      - Wed, 16 Dec 2015 19:31:56 GMT
+      - Fri, 08 Jan 2016 19:18:17 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:31:56 GMT
+  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 - request:
     method: put
     uri: http://192.168.99.100:12345/v1/AUTH_test/the_container/the_object?multipart-manifest=put
@@ -43,14 +43,14 @@ http_interactions:
       string: '[{"path":"the_container/the_object/1","etag":"9e42a695a672299a8fd4e9b5195e7d70","size_bytes":24}]'
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:31:57 GMT
+      - Fri, 08 Jan 2016 19:18:18 GMT
       Content-Length:
       - '0'
       Etag:
@@ -58,12 +58,12 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx23ef08a9637e40e7952a6-005671bc2c
+      - tx2da6f567916e49a3a2334-0056900b79
       Date:
-      - Wed, 16 Dec 2015 19:31:56 GMT
+      - Fri, 08 Jan 2016 19:18:17 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:31:56 GMT
+  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_respond_to_register_keys.yml
+++ b/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_respond_to_register_keys.yml
@@ -19,22 +19,22 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       Content-Length:
       - '0'
       X-Trans-Id:
-      - txccb09861e324454d94679-005671bc2c
+      - txb83b88445709464b9a77d-0056900b79
       Date:
-      - Wed, 16 Dec 2015 19:31:56 GMT
+      - Fri, 08 Jan 2016 19:18:17 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:31:56 GMT
+  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 - request:
     method: post
     uri: http://192.168.99.100:12345/v1/AUTH_test
@@ -43,11 +43,11 @@ http_interactions:
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       X-Account-Meta-Temp-Url-Key:
-      - 048a6cc0d252214d13fa7c0a09362eae
+      - 1e223ad09b49e1adcb8743c0941e45e9
       X-Account-Meta-Temp-Url-Key-2:
-      - df33397eb235dfead5d798b9ef8d1274
+      - ae39a51e92798e27cca68a3a3cc28b50
   response:
     status:
       code: 204
@@ -58,12 +58,12 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx6fa08e984e5c44749595e-005671bc2c
+      - tx76db32ba841c432bad74b-0056900b79
       Date:
-      - Wed, 16 Dec 2015 19:31:56 GMT
+      - Fri, 08 Jan 2016 19:18:17 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:31:56 GMT
+  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_respond_to_storage_url.yml
+++ b/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_respond_to_storage_url.yml
@@ -19,20 +19,20 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       Content-Length:
       - '0'
       X-Trans-Id:
-      - tx9289b8f1dcd742309d4a3-005671bc2c
+      - tx4a34f80bc82641a49c508-0056900b79
       Date:
-      - Wed, 16 Dec 2015 19:31:56 GMT
+      - Fri, 08 Jan 2016 19:18:17 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:31:56 GMT
+  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_set_X-Container-Meta-Access-Control-Allow-Origin.yml
+++ b/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_set_X-Container-Meta-Access-Control-Allow-Origin.yml
@@ -19,22 +19,22 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       Content-Length:
       - '0'
       X-Trans-Id:
-      - tx3d70ce8a856f451c90c7c-005671bc2c
+      - txa80e16a4e6db4dd1aea85-0056900b79
       Date:
-      - Wed, 16 Dec 2015 19:31:56 GMT
+      - Fri, 08 Jan 2016 19:18:17 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:31:56 GMT
+  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 - request:
     method: put
     uri: http://192.168.99.100:12345/v1/AUTH_test/the_container
@@ -43,7 +43,7 @@ http_interactions:
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
       X-Container-Meta-Access-Control-Allow-Origin:
       - "*"
   response:
@@ -56,14 +56,14 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx59d65f5726bf4cb5a4842-005671bc2c
+      - txc77e8a18f707480098ae8-0056900b79
       Date:
-      - Wed, 16 Dec 2015 19:31:56 GMT
+      - Fri, 08 Jan 2016 19:18:17 GMT
     body:
       encoding: UTF-8
       string: "<html><h1>Accepted</h1><p>The request is accepted for processing.</p></html>"
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:31:56 GMT
+  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 - request:
     method: get
     uri: http://192.168.99.100:12345/v1/AUTH_test/the_container
@@ -72,7 +72,7 @@ http_interactions:
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
   response:
     status:
       code: 204
@@ -85,7 +85,7 @@ http_interactions:
       Accept-Ranges:
       - bytes
       X-Timestamp:
-      - '1450294316.26977'
+      - '1452280697.17149'
       X-Container-Meta-Access-Control-Allow-Origin:
       - "*"
       X-Container-Bytes-Used:
@@ -93,12 +93,12 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - txf8ee8fb0ff1c4e3a99349-005671bc2c
+      - tx36b6fe6adad44d2998ff7-0056900b79
       Date:
-      - Wed, 16 Dec 2015 19:31:56 GMT
+      - Fri, 08 Jan 2016 19:18:17 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:31:56 GMT
+  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_store_both_the_content_type_and_filename_on_the_manifest_object.yml
+++ b/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_store_both_the_content_type_and_filename_on_the_manifest_object.yml
@@ -27,7 +27,7 @@ http_interactions:
       Content-Length:
       - '0'
       X-Trans-Id:
-      - txac1531d51eb048c6bd67c-0056900b79
+      - tx39ca904151fa43e8bc546-0056900b79
       Date:
       - Fri, 08 Jan 2016 19:18:17 GMT
     body:
@@ -37,42 +37,17 @@ http_interactions:
   recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/the_container
+    uri: http://192.168.99.100:12345/v1/AUTH_test/the_container/the_object?multipart-manifest=put
     body:
       encoding: UTF-8
-      string: ''
+      string: '[{"path":"the_container/the_object/1","etag":"9e42a695a672299a8fd4e9b5195e7d70","size_bytes":24}]'
     headers:
       X-Auth-Token:
       - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
-      X-Container-Meta-Access-Control-Allow-Origin:
-      - "*"
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Length:
-      - '76'
       Content-Type:
-      - text/html; charset=UTF-8
-      X-Trans-Id:
-      - tx19e35896de9d41749c457-0056900b79
-      Date:
-      - Fri, 08 Jan 2016 19:18:17 GMT
-    body:
-      encoding: UTF-8
-      string: "<html><h1>Accepted</h1><p>The request is accepted for processing.</p></html>"
-    http_version: 
-  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
-- request:
-    method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/the_container/the_object/1
-    body:
-      encoding: UTF-8
-      string: This is the object body!
-    headers:
-      X-Auth-Token:
-      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
+      - text/plain
+      Content-Disposition:
+      - attachment; filename=text_file.txt
   response:
     status:
       code: 201
@@ -83,11 +58,11 @@ http_interactions:
       Content-Length:
       - '0'
       Etag:
-      - 9e42a695a672299a8fd4e9b5195e7d70
+      - '"70f457e8bdf12b30ed18c5b110740c2e"'
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx9ea6ca63a20e422492cbb-0056900b79
+      - txe94b2ba6c0a94a419f737-0056900b79
       Date:
       - Fri, 08 Jan 2016 19:18:17 GMT
     body:
@@ -97,7 +72,7 @@ http_interactions:
   recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 - request:
     method: head
-    uri: http://192.168.99.100:12345/v1/AUTH_test/the_container/the_object/1
+    uri: http://192.168.99.100:12345/v1/AUTH_test/the_container/the_object
     body:
       encoding: US-ASCII
       string: ''
@@ -111,18 +86,22 @@ http_interactions:
     headers:
       Content-Length:
       - '24'
+      Content-Disposition:
+      - attachment; filename=text_file.txt
       Accept-Ranges:
       - bytes
       Last-Modified:
       - Fri, 08 Jan 2016 19:18:18 GMT
       Etag:
-      - 9e42a695a672299a8fd4e9b5195e7d70
+      - '"70f457e8bdf12b30ed18c5b110740c2e"'
       X-Timestamp:
-      - '1452280697.32903'
+      - '1452280697.51237'
+      X-Static-Large-Object:
+      - 'True'
       Content-Type:
-      - application/x-www-form-urlencoded
+      - text/plain
       X-Trans-Id:
-      - tx65323c58ede14c1e86bd6-0056900b79
+      - txedb39092c8404f9cb8590-0056900b79
       Date:
       - Fri, 08 Jan 2016 19:18:17 GMT
     body:

--- a/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_store_the_content_type_on_the_manifest_object_as_the_content-type.yml
+++ b/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_store_the_content_type_on_the_manifest_object_as_the_content-type.yml
@@ -27,7 +27,7 @@ http_interactions:
       Content-Length:
       - '0'
       X-Trans-Id:
-      - txac1531d51eb048c6bd67c-0056900b79
+      - txcf17b92113454b5f9d0dc-0056900b79
       Date:
       - Fri, 08 Jan 2016 19:18:17 GMT
     body:
@@ -37,42 +37,15 @@ http_interactions:
   recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/the_container
+    uri: http://192.168.99.100:12345/v1/AUTH_test/the_container/the_object?multipart-manifest=put
     body:
       encoding: UTF-8
-      string: ''
+      string: '[{"path":"the_container/the_object/1","etag":"9e42a695a672299a8fd4e9b5195e7d70","size_bytes":24}]'
     headers:
       X-Auth-Token:
       - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
-      X-Container-Meta-Access-Control-Allow-Origin:
-      - "*"
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Length:
-      - '76'
       Content-Type:
-      - text/html; charset=UTF-8
-      X-Trans-Id:
-      - tx19e35896de9d41749c457-0056900b79
-      Date:
-      - Fri, 08 Jan 2016 19:18:17 GMT
-    body:
-      encoding: UTF-8
-      string: "<html><h1>Accepted</h1><p>The request is accepted for processing.</p></html>"
-    http_version: 
-  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
-- request:
-    method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/the_container/the_object/1
-    body:
-      encoding: UTF-8
-      string: This is the object body!
-    headers:
-      X-Auth-Token:
-      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
+      - text/plain
   response:
     status:
       code: 201
@@ -83,11 +56,11 @@ http_interactions:
       Content-Length:
       - '0'
       Etag:
-      - 9e42a695a672299a8fd4e9b5195e7d70
+      - '"70f457e8bdf12b30ed18c5b110740c2e"'
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx9ea6ca63a20e422492cbb-0056900b79
+      - tx9acece21f20942559f94a-0056900b79
       Date:
       - Fri, 08 Jan 2016 19:18:17 GMT
     body:
@@ -97,7 +70,7 @@ http_interactions:
   recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 - request:
     method: head
-    uri: http://192.168.99.100:12345/v1/AUTH_test/the_container/the_object/1
+    uri: http://192.168.99.100:12345/v1/AUTH_test/the_container/the_object
     body:
       encoding: US-ASCII
       string: ''
@@ -116,13 +89,15 @@ http_interactions:
       Last-Modified:
       - Fri, 08 Jan 2016 19:18:18 GMT
       Etag:
-      - 9e42a695a672299a8fd4e9b5195e7d70
+      - '"70f457e8bdf12b30ed18c5b110740c2e"'
       X-Timestamp:
-      - '1452280697.32903'
+      - '1452280697.41375'
+      X-Static-Large-Object:
+      - 'True'
       Content-Type:
-      - application/x-www-form-urlencoded
+      - text/plain
       X-Trans-Id:
-      - tx65323c58ede14c1e86bd6-0056900b79
+      - tx473a7d81921b45a2996f0-0056900b79
       Date:
       - Fri, 08 Jan 2016 19:18:17 GMT
     body:

--- a/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_store_the_filename_on_the_manifest_object_in_the_content-disposition.yml
+++ b/spec/cassettes/StorageProvider/methods_that_call_swift_api/should_store_the_filename_on_the_manifest_object_in_the_content-disposition.yml
@@ -27,7 +27,7 @@ http_interactions:
       Content-Length:
       - '0'
       X-Trans-Id:
-      - txac1531d51eb048c6bd67c-0056900b79
+      - tx9d35a52b648246859484b-0056900b79
       Date:
       - Fri, 08 Jan 2016 19:18:17 GMT
     body:
@@ -37,42 +37,15 @@ http_interactions:
   recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/the_container
+    uri: http://192.168.99.100:12345/v1/AUTH_test/the_container/the_object?multipart-manifest=put
     body:
       encoding: UTF-8
-      string: ''
+      string: '[{"path":"the_container/the_object/1","etag":"9e42a695a672299a8fd4e9b5195e7d70","size_bytes":24}]'
     headers:
       X-Auth-Token:
       - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
-      X-Container-Meta-Access-Control-Allow-Origin:
-      - "*"
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Content-Length:
-      - '76'
-      Content-Type:
-      - text/html; charset=UTF-8
-      X-Trans-Id:
-      - tx19e35896de9d41749c457-0056900b79
-      Date:
-      - Fri, 08 Jan 2016 19:18:17 GMT
-    body:
-      encoding: UTF-8
-      string: "<html><h1>Accepted</h1><p>The request is accepted for processing.</p></html>"
-    http_version: 
-  recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
-- request:
-    method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/the_container/the_object/1
-    body:
-      encoding: UTF-8
-      string: This is the object body!
-    headers:
-      X-Auth-Token:
-      - AUTH_tkd5efb75298bc4d82b4670cdb1f639fe5
+      Content-Disposition:
+      - attachment; filename=text_file.txt
   response:
     status:
       code: 201
@@ -83,11 +56,11 @@ http_interactions:
       Content-Length:
       - '0'
       Etag:
-      - 9e42a695a672299a8fd4e9b5195e7d70
+      - '"70f457e8bdf12b30ed18c5b110740c2e"'
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx9ea6ca63a20e422492cbb-0056900b79
+      - tx001b43911b284777ad8c2-0056900b79
       Date:
       - Fri, 08 Jan 2016 19:18:17 GMT
     body:
@@ -97,7 +70,7 @@ http_interactions:
   recorded_at: Fri, 08 Jan 2016 19:18:17 GMT
 - request:
     method: head
-    uri: http://192.168.99.100:12345/v1/AUTH_test/the_container/the_object/1
+    uri: http://192.168.99.100:12345/v1/AUTH_test/the_container/the_object
     body:
       encoding: US-ASCII
       string: ''
@@ -111,18 +84,22 @@ http_interactions:
     headers:
       Content-Length:
       - '24'
+      Content-Disposition:
+      - attachment; filename=text_file.txt
       Accept-Ranges:
       - bytes
       Last-Modified:
       - Fri, 08 Jan 2016 19:18:18 GMT
       Etag:
-      - 9e42a695a672299a8fd4e9b5195e7d70
+      - '"70f457e8bdf12b30ed18c5b110740c2e"'
       X-Timestamp:
-      - '1452280697.32903'
+      - '1452280697.46489'
+      X-Static-Large-Object:
+      - 'True'
       Content-Type:
       - application/x-www-form-urlencoded
       X-Trans-Id:
-      - tx65323c58ede14c1e86bd6-0056900b79
+      - tx1572f6d9332a4be6a2296-0056900b79
       Date:
       - Fri, 08 Jan 2016 19:18:17 GMT
     body:

--- a/spec/cassettes/Upload/swift_methods/complete/calls/with_reported_chunk_hash_not_equal_to_swift_computed_chunk_etag/should_update_completed_at_error_at_and_error_message_and_raise_an_IntegrityException.yml
+++ b/spec/cassettes/Upload/swift_methods/complete/calls/with_reported_chunk_hash_not_equal_to_swift_computed_chunk_etag/should_update_completed_at_error_at_and_error_message_and_raise_an_IntegrityException.yml
@@ -19,31 +19,31 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
       Content-Length:
       - '0'
       X-Trans-Id:
-      - tx3c7a3ea4cd9d4d468668e-005671bc44
+      - tx76fbd0f3e6b2489abadf4-005690155b
       Date:
-      - Wed, 16 Dec 2015 19:32:20 GMT
+      - Fri, 08 Jan 2016 20:00:27 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:20 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:27 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/545d0020-1ab6-43f0-ab1c-9f7fed6190c0
+    uri: http://192.168.99.100:12345/v1/AUTH_test/4f22148c-b28a-45ca-a000-276f9b5d4f3d
     body:
       encoding: UTF-8
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
       X-Container-Meta-Access-Control-Allow-Origin:
       - "*"
   response:
@@ -56,30 +56,30 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx88d672f0172440bf9ce49-005671bc44
+      - txb038cd1ccfb74b5581f01-005690155b
       Date:
-      - Wed, 16 Dec 2015 19:32:20 GMT
+      - Fri, 08 Jan 2016 20:00:27 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:20 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:27 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/545d0020-1ab6-43f0-ab1c-9f7fed6190c0/96807da3-73c9-4e09-b337-b2c9112d6e5a/1
+    uri: http://192.168.99.100:12345/v1/AUTH_test/4f22148c-b28a-45ca-a000-276f9b5d4f3d/0a329ecb-c92d-45fa-880b-91b068779f20/1
     body:
       encoding: UTF-8
       string: this is a chunk
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:32:21 GMT
+      - Fri, 08 Jan 2016 20:00:28 GMT
       Content-Length:
       - '0'
       Etag:
@@ -87,23 +87,27 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx1006bca314f145b4817d8-005671bc44
+      - txeaa1fcee28ea4a0fb3e36-005690155b
       Date:
-      - Wed, 16 Dec 2015 19:32:20 GMT
+      - Fri, 08 Jan 2016 20:00:27 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:20 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:27 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/545d0020-1ab6-43f0-ab1c-9f7fed6190c0/96807da3-73c9-4e09-b337-b2c9112d6e5a?multipart-manifest=put
+    uri: http://192.168.99.100:12345/v1/AUTH_test/4f22148c-b28a-45ca-a000-276f9b5d4f3d/0a329ecb-c92d-45fa-880b-91b068779f20?multipart-manifest=put
     body:
       encoding: UTF-8
-      string: '[{"path":"545d0020-1ab6-43f0-ab1c-9f7fed6190c0/96807da3-73c9-4e09-b337-b2c9112d6e5a/1","etag":"NOTTHECOMPUTEDHASH","size_bytes":15}]'
+      string: '[{"path":"4f22148c-b28a-45ca-a000-276f9b5d4f3d/0a329ecb-c92d-45fa-880b-91b068779f20/1","etag":"NOTTHECOMPUTEDHASH","size_bytes":15}]'
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
+      Content-Type:
+      - text/plain
+      Content-Disposition:
+      - attachment; filename=qui.nam
   response:
     status:
       code: 400
@@ -114,16 +118,16 @@ http_interactions:
       Content-Type:
       - text/plain
       X-Trans-Id:
-      - tx4a44b557090043e9bf534-005671bc44
+      - tx5b10accfcdc4437fbca89-005690155b
       Date:
-      - Wed, 16 Dec 2015 19:32:20 GMT
+      - Fri, 08 Jan 2016 20:00:27 GMT
     body:
       encoding: UTF-8
       string: |-
         Errors:
-        545d0020-1ab6-43f0-ab1c-9f7fed6190c0/96807da3-73c9-4e09-b337-b2c9112d6e5a/1, Etag Mismatch
+        4f22148c-b28a-45ca-a000-276f9b5d4f3d/0a329ecb-c92d-45fa-880b-91b068779f20/1, Etag Mismatch
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:20 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:27 GMT
 - request:
     method: get
     uri: http://192.168.99.100:12345/auth/v1.0
@@ -143,31 +147,31 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
       Content-Length:
       - '0'
       X-Trans-Id:
-      - txa664f2907df143b89111f-005671bc44
+      - tx673795be42374b0dbfde2-005690155b
       Date:
-      - Wed, 16 Dec 2015 19:32:20 GMT
+      - Fri, 08 Jan 2016 20:00:27 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:20 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:27 GMT
 - request:
     method: delete
-    uri: http://192.168.99.100:12345/v1/AUTH_test/545d0020-1ab6-43f0-ab1c-9f7fed6190c0/96807da3-73c9-4e09-b337-b2c9112d6e5a/1?multipart-manifest=delete
+    uri: http://192.168.99.100:12345/v1/AUTH_test/4f22148c-b28a-45ca-a000-276f9b5d4f3d/0a329ecb-c92d-45fa-880b-91b068779f20/1?multipart-manifest=delete
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
   response:
     status:
       code: 200
@@ -176,16 +180,16 @@ http_interactions:
       Content-Type:
       - text/plain
       X-Trans-Id:
-      - tx54d630fef82549e4b694c-005671bc44
+      - tx55dc195feaf7429ca674b-005690155b
       Date:
-      - Wed, 16 Dec 2015 19:32:20 GMT
+      - Fri, 08 Jan 2016 20:00:27 GMT
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: "Number Deleted: 0\nNumber Not Found: 0\nResponse Body: \nResponse Status:
-        400 Bad Request\nErrors:\n/545d0020-1ab6-43f0-ab1c-9f7fed6190c0/96807da3-73c9-4e09-b337-b2c9112d6e5a/1,
+        400 Bad Request\nErrors:\n/4f22148c-b28a-45ca-a000-276f9b5d4f3d/0a329ecb-c92d-45fa-880b-91b068779f20/1,
         Not an SLO manifest"
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:20 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:27 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/Upload/swift_methods/complete/calls/with_reported_size_not_equal_to_swift_computed_size/should_update_completed_at_error_at_and_error_message_and_raise_an_IntegrityException.yml
+++ b/spec/cassettes/Upload/swift_methods/complete/calls/with_reported_size_not_equal_to_swift_computed_size/should_update_completed_at_error_at_and_error_message_and_raise_an_IntegrityException.yml
@@ -19,31 +19,31 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
       Content-Length:
       - '0'
       X-Trans-Id:
-      - tx830b78b640e1479a94d44-005671bc43
+      - tx99494186822a463abf0fa-005690155a
       Date:
-      - Wed, 16 Dec 2015 19:32:19 GMT
+      - Fri, 08 Jan 2016 20:00:26 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:19 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:26 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/c6c7f85d-7a50-4a41-9cff-10e665dd6141
+    uri: http://192.168.99.100:12345/v1/AUTH_test/59b26bd5-b3d1-4612-b654-4084b092fe97
     body:
       encoding: UTF-8
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
       X-Container-Meta-Access-Control-Allow-Origin:
       - "*"
   response:
@@ -56,30 +56,30 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx8b7c0b1823c94ba48a73b-005671bc43
+      - tx0eb0c73b9f2e4aa6ae965-005690155a
       Date:
-      - Wed, 16 Dec 2015 19:32:19 GMT
+      - Fri, 08 Jan 2016 20:00:26 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:19 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:26 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/c6c7f85d-7a50-4a41-9cff-10e665dd6141/51e55a8b-897e-4e4e-914b-f8850a432512/1
+    uri: http://192.168.99.100:12345/v1/AUTH_test/59b26bd5-b3d1-4612-b654-4084b092fe97/b495974b-e9c6-489e-b0d1-cba5bed06553/1
     body:
       encoding: UTF-8
       string: this is a chunk
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:32:20 GMT
+      - Fri, 08 Jan 2016 20:00:27 GMT
       Content-Length:
       - '0'
       Etag:
@@ -87,30 +87,34 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx7bc136bd2d6a439887e0a-005671bc43
+      - txd8bd46a17d1c4c339dd9e-005690155a
       Date:
-      - Wed, 16 Dec 2015 19:32:19 GMT
+      - Fri, 08 Jan 2016 20:00:26 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:19 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:26 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/c6c7f85d-7a50-4a41-9cff-10e665dd6141/51e55a8b-897e-4e4e-914b-f8850a432512?multipart-manifest=put
+    uri: http://192.168.99.100:12345/v1/AUTH_test/59b26bd5-b3d1-4612-b654-4084b092fe97/b495974b-e9c6-489e-b0d1-cba5bed06553?multipart-manifest=put
     body:
       encoding: UTF-8
-      string: '[{"path":"c6c7f85d-7a50-4a41-9cff-10e665dd6141/51e55a8b-897e-4e4e-914b-f8850a432512/1","etag":"2b1f638751fa49d7fba5a64fecf48bb2","size_bytes":15}]'
+      string: '[{"path":"59b26bd5-b3d1-4612-b654-4084b092fe97/b495974b-e9c6-489e-b0d1-cba5bed06553/1","etag":"2b1f638751fa49d7fba5a64fecf48bb2","size_bytes":15}]'
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
+      Content-Type:
+      - text/plain
+      Content-Disposition:
+      - attachment; filename=inventore-fugit
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:32:21 GMT
+      - Fri, 08 Jan 2016 20:00:27 GMT
       Content-Length:
       - '0'
       Etag:
@@ -118,23 +122,23 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx766abda882414fd88e595-005671bc44
+      - tx7dd59448f1eb478cb2da1-005690155a
       Date:
-      - Wed, 16 Dec 2015 19:32:20 GMT
+      - Fri, 08 Jan 2016 20:00:26 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:20 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:26 GMT
 - request:
     method: head
-    uri: http://192.168.99.100:12345/v1/AUTH_test/c6c7f85d-7a50-4a41-9cff-10e665dd6141/51e55a8b-897e-4e4e-914b-f8850a432512
+    uri: http://192.168.99.100:12345/v1/AUTH_test/59b26bd5-b3d1-4612-b654-4084b092fe97/b495974b-e9c6-489e-b0d1-cba5bed06553
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
   response:
     status:
       code: 200
@@ -142,27 +146,29 @@ http_interactions:
     headers:
       Content-Length:
       - '15'
+      Content-Disposition:
+      - attachment; filename=inventore-fugit
       Accept-Ranges:
       - bytes
       Last-Modified:
-      - Wed, 16 Dec 2015 19:32:21 GMT
+      - Fri, 08 Jan 2016 20:00:27 GMT
       Etag:
       - '"b77622f6f760a1bed182840a7c02a53c"'
       X-Timestamp:
-      - '1450294340.02808'
+      - '1452283226.82726'
       X-Static-Large-Object:
       - 'True'
       Content-Type:
-      - application/x-www-form-urlencoded
+      - text/plain
       X-Trans-Id:
-      - tx18562f30e68f4408af970-005671bc44
+      - tx75d4370ed5bc41f1b72e8-005690155a
       Date:
-      - Wed, 16 Dec 2015 19:32:20 GMT
+      - Fri, 08 Jan 2016 20:00:26 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:20 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:26 GMT
 - request:
     method: get
     uri: http://192.168.99.100:12345/auth/v1.0
@@ -182,31 +188,31 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
       Content-Length:
       - '0'
       X-Trans-Id:
-      - txcd9e764aca674fe1a9206-005671bc44
+      - txe1c5c12e34ec431bae407-005690155a
       Date:
-      - Wed, 16 Dec 2015 19:32:20 GMT
+      - Fri, 08 Jan 2016 20:00:26 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:20 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:26 GMT
 - request:
     method: delete
-    uri: http://192.168.99.100:12345/v1/AUTH_test/c6c7f85d-7a50-4a41-9cff-10e665dd6141/51e55a8b-897e-4e4e-914b-f8850a432512/1?multipart-manifest=delete
+    uri: http://192.168.99.100:12345/v1/AUTH_test/59b26bd5-b3d1-4612-b654-4084b092fe97/b495974b-e9c6-489e-b0d1-cba5bed06553/1?multipart-manifest=delete
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
   response:
     status:
       code: 200
@@ -215,16 +221,16 @@ http_interactions:
       Content-Type:
       - text/plain
       X-Trans-Id:
-      - txd20ab998ef1f432890913-005671bc44
+      - tx69969db804d749f3ab075-005690155a
       Date:
-      - Wed, 16 Dec 2015 19:32:20 GMT
+      - Fri, 08 Jan 2016 20:00:26 GMT
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: "Number Deleted: 0\nNumber Not Found: 0\nResponse Body: \nResponse Status:
-        400 Bad Request\nErrors:\n/c6c7f85d-7a50-4a41-9cff-10e665dd6141/51e55a8b-897e-4e4e-914b-f8850a432512/1,
+        400 Bad Request\nErrors:\n/59b26bd5-b3d1-4612-b654-4084b092fe97/b495974b-e9c6-489e-b0d1-cba5bed06553/1,
         Not an SLO manifest"
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:20 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:26 GMT
 recorded_with: VCR 3.0.0

--- a/spec/cassettes/Upload/swift_methods/complete/calls/with_valid_reported_size_and_chunk_hashes/should_update_completed_at_leave_error_at_and_error_message_null_and_return_true.yml
+++ b/spec/cassettes/Upload/swift_methods/complete/calls/with_valid_reported_size_and_chunk_hashes/should_update_completed_at_leave_error_at_and_error_message_null_and_return_true.yml
@@ -19,31 +19,31 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
       Content-Length:
       - '0'
       X-Trans-Id:
-      - txe01cb49cdff34e78b7356-005671bc43
+      - txefa6e3a51dae4590b4c2e-005690155a
       Date:
-      - Wed, 16 Dec 2015 19:32:19 GMT
+      - Fri, 08 Jan 2016 20:00:26 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:19 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:26 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/97cca90d-7841-48a7-9082-6bf44ea9a23d
+    uri: http://192.168.99.100:12345/v1/AUTH_test/450b5f72-537f-418f-966a-17ca4b2b54b5
     body:
       encoding: UTF-8
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
       X-Container-Meta-Access-Control-Allow-Origin:
       - "*"
   response:
@@ -56,30 +56,30 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - txbf84758ceab34ae89b3c1-005671bc43
+      - tx29ac1ea554d445ff845e3-005690155a
       Date:
-      - Wed, 16 Dec 2015 19:32:19 GMT
+      - Fri, 08 Jan 2016 20:00:26 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:19 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:26 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/97cca90d-7841-48a7-9082-6bf44ea9a23d/ac9e7b68-ae01-4069-b8c5-8a6856afaf05/1
+    uri: http://192.168.99.100:12345/v1/AUTH_test/450b5f72-537f-418f-966a-17ca4b2b54b5/c79b4426-6507-442e-8698-f466762e2736/1
     body:
       encoding: UTF-8
       string: this is a chunk
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:32:20 GMT
+      - Fri, 08 Jan 2016 20:00:27 GMT
       Content-Length:
       - '0'
       Etag:
@@ -87,30 +87,34 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - tx27fcdb1a336848bbbbd34-005671bc43
+      - tx9a369528457d4f94a769f-005690155a
       Date:
-      - Wed, 16 Dec 2015 19:32:19 GMT
+      - Fri, 08 Jan 2016 20:00:26 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:19 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:26 GMT
 - request:
     method: put
-    uri: http://192.168.99.100:12345/v1/AUTH_test/97cca90d-7841-48a7-9082-6bf44ea9a23d/ac9e7b68-ae01-4069-b8c5-8a6856afaf05?multipart-manifest=put
+    uri: http://192.168.99.100:12345/v1/AUTH_test/450b5f72-537f-418f-966a-17ca4b2b54b5/c79b4426-6507-442e-8698-f466762e2736?multipart-manifest=put
     body:
       encoding: UTF-8
-      string: '[{"path":"97cca90d-7841-48a7-9082-6bf44ea9a23d/ac9e7b68-ae01-4069-b8c5-8a6856afaf05/1","etag":"2b1f638751fa49d7fba5a64fecf48bb2","size_bytes":15}]'
+      string: '[{"path":"450b5f72-537f-418f-966a-17ca4b2b54b5/c79b4426-6507-442e-8698-f466762e2736/1","etag":"2b1f638751fa49d7fba5a64fecf48bb2","size_bytes":15}]'
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
+      Content-Type:
+      - text/plain
+      Content-Disposition:
+      - attachment; filename=consectetur-quia
   response:
     status:
       code: 201
       message: Created
     headers:
       Last-Modified:
-      - Wed, 16 Dec 2015 19:32:20 GMT
+      - Fri, 08 Jan 2016 20:00:27 GMT
       Content-Length:
       - '0'
       Etag:
@@ -118,23 +122,23 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       X-Trans-Id:
-      - txb6877d5406ab450e8a523-005671bc43
+      - tx8c57a21fd4de48cfb08d5-005690155a
       Date:
-      - Wed, 16 Dec 2015 19:32:19 GMT
+      - Fri, 08 Jan 2016 20:00:26 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:19 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:26 GMT
 - request:
     method: head
-    uri: http://192.168.99.100:12345/v1/AUTH_test/97cca90d-7841-48a7-9082-6bf44ea9a23d/ac9e7b68-ae01-4069-b8c5-8a6856afaf05
+    uri: http://192.168.99.100:12345/v1/AUTH_test/450b5f72-537f-418f-966a-17ca4b2b54b5/c79b4426-6507-442e-8698-f466762e2736
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
   response:
     status:
       code: 200
@@ -142,27 +146,29 @@ http_interactions:
     headers:
       Content-Length:
       - '15'
+      Content-Disposition:
+      - attachment; filename=consectetur-quia
       Accept-Ranges:
       - bytes
       Last-Modified:
-      - Wed, 16 Dec 2015 19:32:20 GMT
+      - Fri, 08 Jan 2016 20:00:27 GMT
       Etag:
       - '"b77622f6f760a1bed182840a7c02a53c"'
       X-Timestamp:
-      - '1450294339.71020'
+      - '1452283226.49117'
       X-Static-Large-Object:
       - 'True'
       Content-Type:
-      - application/x-www-form-urlencoded
+      - text/plain
       X-Trans-Id:
-      - tx952781302a28481da11ad-005671bc43
+      - tx921936dbb9cd42d39bb35-005690155a
       Date:
-      - Wed, 16 Dec 2015 19:32:19 GMT
+      - Fri, 08 Jan 2016 20:00:26 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:19 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:26 GMT
 - request:
     method: get
     uri: http://192.168.99.100:12345/auth/v1.0
@@ -182,31 +188,31 @@ http_interactions:
       X-Storage-Url:
       - http://192.168.99.100:12345/v1/AUTH_test
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
       Content-Type:
       - text/html; charset=UTF-8
       X-Storage-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
       Content-Length:
       - '0'
       X-Trans-Id:
-      - txe0eed09f88be4efe80939-005671bc43
+      - tx85bb71e19c6546ec80746-005690155a
       Date:
-      - Wed, 16 Dec 2015 19:32:19 GMT
+      - Fri, 08 Jan 2016 20:00:26 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:19 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:26 GMT
 - request:
     method: delete
-    uri: http://192.168.99.100:12345/v1/AUTH_test/97cca90d-7841-48a7-9082-6bf44ea9a23d/ac9e7b68-ae01-4069-b8c5-8a6856afaf05/1?multipart-manifest=delete
+    uri: http://192.168.99.100:12345/v1/AUTH_test/450b5f72-537f-418f-966a-17ca4b2b54b5/c79b4426-6507-442e-8698-f466762e2736/1?multipart-manifest=delete
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Auth-Token:
-      - AUTH_tk873232b138f0496680a71aa498ea3103
+      - AUTH_tkb186d728b4514d76b90b7c49eabfa36d
   response:
     status:
       code: 200
@@ -215,16 +221,16 @@ http_interactions:
       Content-Type:
       - text/plain
       X-Trans-Id:
-      - tx5209ad9a0cee4ba2a49d1-005671bc43
+      - tx31877968ecb342b9b8500-005690155a
       Date:
-      - Wed, 16 Dec 2015 19:32:19 GMT
+      - Fri, 08 Jan 2016 20:00:26 GMT
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: "Number Deleted: 0\nNumber Not Found: 0\nResponse Body: \nResponse Status:
-        400 Bad Request\nErrors:\n/97cca90d-7841-48a7-9082-6bf44ea9a23d/ac9e7b68-ae01-4069-b8c5-8a6856afaf05/1,
+        400 Bad Request\nErrors:\n/450b5f72-537f-418f-966a-17ca4b2b54b5/c79b4426-6507-442e-8698-f466762e2736/1,
         Not an SLO manifest"
     http_version: 
-  recorded_at: Wed, 16 Dec 2015 19:32:19 GMT
+  recorded_at: Fri, 08 Jan 2016 20:00:26 GMT
 recorded_with: VCR 3.0.0

--- a/spec/models/storage_provider_spec.rb
+++ b/spec/models/storage_provider_spec.rb
@@ -58,7 +58,6 @@ RSpec.describe StorageProvider, type: :model do
       is_expected.to respond_to :put_container
       expect { put_container }.not_to raise_error
       expect(put_container).to be_truthy
-      subject.delete_container(container_name)
     end
 
     let(:put_container_meta){
@@ -66,20 +65,16 @@ RSpec.describe StorageProvider, type: :model do
       HTTParty.get("#{subject.storage_url}/#{container_name}", headers:{"X-Auth-Token" => subject.auth_token})
     }
     it 'should set X-Container-Meta-Access-Control-Allow-Origin' do
-      subject.put_container(container_name)
       expect { put_container_meta }.not_to raise_error
       expect(put_container_meta.headers).to have_key 'x-container-meta-access-control-allow-origin'
       expect(put_container_meta.headers['x-container-meta-access-control-allow-origin']).to eq '*'
-      subject.delete_container(container_name)
     end
 
     let(:put_object) { subject.put_object(container_name, segment_name, object_body) }
     it 'should respond to put_object' do
-      subject.put_container(container_name)
       is_expected.to respond_to :put_object
       expect { put_object }.not_to raise_error
       expect(put_object).to be_truthy
-      subject.delete_container(container_name)
     end
 
     let(:get_object_metadata) { subject.get_object_metadata(container_name, segment_name) }
@@ -91,79 +86,55 @@ RSpec.describe StorageProvider, type: :model do
         resp = get_object_metadata
         expect(resp).to be
       }.not_to raise_error
-      subject.delete_container(container_name)
     end
 
-    describe 'put_object_manifest' do
-      describe 'without content_type and filename' do
-        let(:put_object_manifest) { subject.put_object_manifest(container_name, object_name, manifest_hash) }
-        it 'should respond to put_object_manifest' do
-          subject.put_container(container_name)
-          is_expected.to respond_to :put_object_manifest
-          expect { put_object_manifest }.not_to raise_error
-          expect(put_object_manifest).to be_truthy
-          subject.delete_container(container_name)
-        end
-      end
+    let(:put_object_manifest) { subject.put_object_manifest(container_name, object_name, manifest_hash) }
+    it 'should respond to put_object_manifest' do
+      is_expected.to respond_to :put_object_manifest
+      expect { put_object_manifest }.not_to raise_error
+      expect(put_object_manifest).to be_truthy
+    end
 
-      describe 'with content_type' do
-        let(:put_object_manifest) {
-          subject.put_object_manifest(container_name, object_name, manifest_hash, content_type)
-        }
-        it 'should store the content_type on the manifest object as the content-type' do
-          subject.put_container(container_name)
-          is_expected.to respond_to :put_object_manifest
-          expect { put_object_manifest }.not_to raise_error
-          expect(put_object_manifest).to be_truthy
-          resp = subject.get_object_metadata(container_name, object_name)
-          expect(resp['content-type']).to eq(content_type)
-          subject.delete_container(container_name)
-        end
-      end
+    let(:put_object_manifest_content_type) {
+      subject.put_object_manifest(container_name, object_name, manifest_hash, content_type)
+    }
+    it 'should store the content_type on the manifest object as the content-type' do
+      expect { put_object_manifest_content_type }.not_to raise_error
+      expect(put_object_manifest_content_type).to be_truthy
+      resp = subject.get_object_metadata(container_name, object_name)
+      expect(resp['content-type']).to eq(content_type)
+    end
 
-      describe 'with filename' do
-        let(:put_object_manifest) {
-          subject.put_object_manifest(container_name, object_name, manifest_hash, nil, filename)
-        }
-        it 'should store the filename on the manifest object in the content-disposition' do
-          subject.put_container(container_name)
-          expect { put_object_manifest }.not_to raise_error
-          expect(put_object_manifest).to be_truthy
-          resp = subject.get_object_metadata(container_name, object_name)
-          expect(resp['content-type']).to eq(content_type)
-          expect(resp['content-disposition']).to eq("attachment; filename=#{filename}")
-          subject.delete_container(container_name)
-        end
-      end
+    let(:put_object_manifest_filename) {
+      subject.put_object_manifest(container_name, object_name, manifest_hash, nil, filename)
+    }
+    it 'should store the filename on the manifest object in the content-disposition' do
+      expect { put_object_manifest_filename }.not_to raise_error
+      expect(put_object_manifest_filename).to be_truthy
+      resp = subject.get_object_metadata(container_name, object_name)
+      expect(resp['content-disposition']).to eq("attachment; filename=#{filename}")
+    end
 
-      describe 'with content_type and filename' do
-        let(:put_object_manifest) {
-          subject.put_object_manifest(container_name, object_name, manifest_hash, content_type, filename)
-        }
-        it 'should store the filename on the manifest object in the content-disposition' do
-          subject.put_container(container_name)
-          expect { put_object_manifest }.not_to raise_error
-          expect(put_object_manifest).to be_truthy
-          resp = subject.get_object_metadata(container_name, object_name)
-          expect(resp['content-disposition']).to eq("attachment; filename=#{filename}")
-          subject.delete_container(container_name)
-        end
-      end
+    let(:put_object_manifest_content_type_filename) {
+      subject.put_object_manifest(container_name, object_name, manifest_hash, content_type, filename)
+    }
+    it 'should store both the content_type and filename on the manifest object' do
+      expect { put_object_manifest_content_type_filename }.not_to raise_error
+      expect(put_object_manifest_content_type_filename).to be_truthy
+      resp = subject.get_object_metadata(container_name, object_name)
+      expect(resp['content-type']).to eq(content_type)
+      expect(resp['content-disposition']).to eq("attachment; filename=#{filename}")
     end
 
     let(:delete_object) { subject.delete_object(container_name, object_name) }
     it 'should respond to delete_object' do
-      subject.put_container(container_name)
-      subject.put_object_manifest(container_name, object_name, manifest_hash, content_type, filename)
       is_expected.to respond_to :delete_object
       expect { delete_object }.not_to raise_error
       expect(delete_object).to be_truthy
-      subject.delete_container(container_name)
     end
 
     let(:delete_container) { subject.delete_container(container_name) }
     it 'should respond to delete_container' do
-      subject.put_container(container_name)
       is_expected.to respond_to :delete_container
       expect { delete_container }.not_to raise_error
       expect(delete_container).to be_truthy


### PR DESCRIPTION
content_type is placed as-is on the content-type metadata for the object
name is stored in the content-disposition metadata for the object as "attachment; filename=#{name}"

also,
VCR cassettes updated
an auth_header method was added to StorageProvider to make it easier to use it in a console
to query the Swift service
