### PR TITLE
another attempt to fix the race condition.

### DIFF
--- a/app/api/dds/v1/users_api.rb
+++ b/app/api/dds/v1/users_api.rb
@@ -40,23 +40,25 @@ module DDS
               new_login_at = DateTime.now
               authorized_user.user.update_attribute(:last_login_at, DateTime.now)
             else
-              new_user = User.new(
-                id: SecureRandom.uuid,
-                username: access_token['uid'],
-                etag: SecureRandom.hex,
-                email: access_token['email'],
-                display_name: access_token['display_name'],
-                first_name: access_token['first_name'],
-                last_login_at: DateTime.now,
-                last_name: access_token['last_name']
-              )
-              authorized_user = new_user.user_authentication_services.build(
-                uid: access_token['uid'],
-                authentication_service: auth_service
-              )
-              new_user.save!
-              last_audit = new_user.audits.last
-              annotate_audits([last_audit], {user: new_user})
+              auth_service.with_lock do
+                new_user = User.new(
+                  id: SecureRandom.uuid,
+                  username: access_token['uid'],
+                  etag: SecureRandom.hex,
+                  email: access_token['email'],
+                  display_name: access_token['display_name'],
+                  first_name: access_token['first_name'],
+                  last_login_at: DateTime.now,
+                  last_name: access_token['last_name']
+                )
+                authorized_user = new_user.user_authentication_services.build(
+                  uid: access_token['uid'],
+                  authentication_service: auth_service
+                )
+                new_user.save!
+                last_audit = new_user.audits.last
+                annotate_audits([last_audit], {user: new_user})
+              end
             end
             {'api_token' => authorized_user.api_token}
           else


### PR DESCRIPTION
This time, users could create multiple user_authentication_services with the same uid and authentication_service id if the request was at the exact same time (which it was).
Putting the entire transaction in a lock on the auth_service ensures that no two requests can do the same
transaction at the same time, which will prevent these duplicates.

D.Mann investigated the fix
