### PR TITLE
Revert "DDS-427 #resolve Logically delete file_versions when DataFile marked is_deleted"

### DIFF
--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -2,13 +2,12 @@
 
 class DataFile < Container
   belongs_to :upload
-  has_many :file_versions, -> { order('version_number ASC') }, autosave: true
+  has_many :file_versions, -> { order('version_number ASC') }
   has_many :tags, as: :taggable
 
   after_set_parent_attribute :set_project_to_parent_project
   before_save :build_file_version, if: :new_file_version_needed?
   before_save :set_current_file_version_attributes
-  before_save :set_file_versions_is_deleted, if: :is_deleted?
 
   validates :project_id, presence: true, immutable: true, unless: :is_deleted
   validates :upload_id, presence: true, unless: :is_deleted
@@ -31,12 +30,6 @@ class DataFile < Container
 
   def url
     upload.temporary_url(name)
-  end
-
-  def set_file_versions_is_deleted
-    file_versions.each do |fv|
-      fv.is_deleted = true
-    end
   end
 
   def kind

--- a/spec/models/data_file_spec.rb
+++ b/spec/models/data_file_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe DataFile, type: :model do
     it { is_expected.to belong_to(:parent) }
     it { is_expected.to belong_to(:upload) }
     it { is_expected.to have_many(:project_permissions).through(:project) }
-    it { is_expected.to have_many(:file_versions).order('version_number ASC').autosave(true) }
+    it { is_expected.to have_many(:file_versions).order('version_number ASC') }
     it { is_expected.to have_many(:tags) }
   end
 
@@ -79,7 +79,6 @@ RSpec.describe DataFile, type: :model do
       it { is_expected.not_to validate_presence_of(:name) }
       it { is_expected.not_to validate_presence_of(:project_id) }
       it { is_expected.not_to validate_presence_of(:upload_id) }
-      it { expect(deleted_file.file_versions).to all( be_is_deleted ) }
     end
   end
 

--- a/spec/requests/files_api_spec.rb
+++ b/spec/requests/files_api_spec.rb
@@ -285,13 +285,6 @@ describe DDS::V1::FilesAPI do
           expect(resource.is_deleted?).to be_truthy
         end
 
-        it 'should mark file_versions as deleted' do
-          expect(resource).to be_persisted
-          expect {
-            is_expected.to eq(204)
-          }.to change{FileVersion.where(is_deleted: true).count}
-        end
-
         it_behaves_like 'an identified resource' do
           let(:resource_id) {'notfoundid'}
         end


### PR DESCRIPTION
Reverts Duke-Translational-Bioinformatics/duke-data-service#633
Needs more testing. These changes are possibly causing the 
rake db:data:migrate to fail.
