### PR TITLE
bugfixes

### DIFF
--- a/app/api/dds/v1/relations_api.rb
+++ b/app/api/dds/v1/relations_api.rb
@@ -40,7 +40,7 @@ module DDS
             annotate_audits [relation.audits.last]
             relation
           else
-            validation_error!(activity)
+            validation_error!(relation)
           end
         end
       end
@@ -84,7 +84,7 @@ module DDS
             annotate_audits [relation.audits.last]
             relation
           else
-            validation_error!(activity)
+            validation_error!(relation)
           end
         end
       end
@@ -128,7 +128,7 @@ module DDS
             annotate_audits [relation.audits.last]
             relation
           else
-            validation_error!(activity)
+            validation_error!(relation)
           end
         end
       end
@@ -171,7 +171,7 @@ module DDS
             annotate_audits [relation.audits.last]
             relation
           else
-            validation_error!(activity)
+            validation_error!(relation)
           end
         end
       end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,6 +1,7 @@
 class Activity < ActiveRecord::Base
   include Kinded
   include Graphed
+  before_create :set_default_started_on
   after_create :create_graph_node
   after_save :logically_delete_graph_node
   after_destroy :delete_graph_node
@@ -20,5 +21,9 @@ class Activity < ActiveRecord::Base
     if  started_on && ended_on && started_on > ended_on
       self.errors.add :ended_on, ' must be >= started_on'
     end
+  end
+
+  def set_default_started_on
+    self.started_on = DateTime.now unless self.started_on
   end
 end

--- a/app/models/prov_relation.rb
+++ b/app/models/prov_relation.rb
@@ -11,6 +11,10 @@ class ProvRelation < ActiveRecord::Base
 
   validates :creator_id, presence: true
   validates :relatable_from, presence: true
+  validates :relationship_type, uniqueness: {
+    scope: [:relatable_from_id, :relatable_to_id],
+    case_sensitive: false
+  }
   validates :relatable_to, presence: true
 
   belongs_to :creator, class_name: "User"

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -3,8 +3,6 @@ FactoryGirl.define do
     name { "#{Faker::Team.name}_#{rand(10**3)}" }
     description { Faker::Hacker.say_something_smart }
     association :creator, factory: :user
-    started_on "2016-04-25 14:37:42"
-    ended_on "2016-04-25 14:37:42"
 
     trait :deleted do
       is_deleted true

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -10,6 +10,27 @@ RSpec.describe Activity, type: :model do
   it_behaves_like 'a logically deleted model'
   it_behaves_like 'a graphed model', auto_create: true, logically_deleted: true
 
+  context 'started_on' do
+    context 'default' do
+      it 'is expected to be set to the current time' do
+        before_time = DateTime.now
+        expect(subject).to be_persisted
+        expect(subject.started_on).not_to be_nil
+        expect(subject.started_on).to be >= before_time
+        expect(subject.started_on).to be <= DateTime.now
+      end
+    end
+
+    context 'set by user' do
+      it 'is expected to be set to the user supplied value' do
+        user_supplied_started_on = 10.minutes.ago
+        new_record = FactoryGirl.create(:activity, started_on: user_supplied_started_on)
+        new_record.reload
+        expect(new_record.started_on.to_i).to be == user_supplied_started_on.to_i
+      end
+    end
+  end
+
   describe 'associations' do
     it { is_expected.to belong_to(:creator).class_name('User') }
     it { is_expected.to have_many(:generated_by_activity_prov_relations) }

--- a/spec/requests/relations_api_spec.rb
+++ b/spec/requests/relations_api_spec.rb
@@ -50,8 +50,18 @@ describe DDS::V1::RelationsAPI do
         }
       }}
       let(:resource_serializer) { UsedProvRelationSerializer }
-
+      let(:duplicate_of_record) {
+        FactoryGirl.create(:used_prov_relation,
+          relatable_from: activity,
+          relatable_to: used_file_version
+        )
+      }
       it_behaves_like 'a creatable resource'
+      it_behaves_like 'a validated resource' do
+        before do
+          expect(duplicate_of_record).to be_persisted
+        end
+      end
 
       context 'with other users activity' do
         let(:payload) {{
@@ -128,8 +138,19 @@ describe DDS::V1::RelationsAPI do
         }
       }}
       let(:resource_serializer) { GeneratedByActivityProvRelationSerializer }
+      let(:duplicate_of_record) {
+        FactoryGirl.create(:generated_by_activity_prov_relation,
+          relatable_from: generated_file_version,
+          relatable_to: activity
+        )
+      }
 
       it_behaves_like 'a creatable resource'
+      it_behaves_like 'a validated resource' do
+        before do
+          expect(duplicate_of_record).to be_persisted
+        end
+      end
 
       context 'with other users activity' do
         let(:payload) {{
@@ -207,8 +228,19 @@ describe DDS::V1::RelationsAPI do
         }
       }}
       let(:resource_serializer) { DerivedFromFileVersionProvRelationSerializer }
+      let(:duplicate_of_record) {
+        FactoryGirl.create(:derived_from_file_version_prov_relation,
+          relatable_from: generated_file_version,
+          relatable_to: used_file_version
+        )
+      }
 
       it_behaves_like 'a creatable resource'
+      it_behaves_like 'a validated resource' do
+        before do
+          expect(duplicate_of_record).to be_persisted
+        end
+      end
 
       context 'without used_entity in payload' do
         let(:payload) {{
@@ -274,6 +306,12 @@ describe DDS::V1::RelationsAPI do
         }
       }}
       let(:resource_serializer) { InvalidatedByActivityProvRelationSerializer }
+      let(:duplicate_of_record) {
+        FactoryGirl.create(:invalidated_by_activity_prov_relation,
+          relatable_from: invalidated_file_version,
+          relatable_to: activity
+        )
+      }
 
       context 'with entity that has not been deleted' do
         before do
@@ -312,6 +350,12 @@ describe DDS::V1::RelationsAPI do
       end
 
       it_behaves_like 'a creatable resource'
+      it_behaves_like 'a validated resource' do
+        before do
+          expect(duplicate_of_record).to be_persisted
+        end
+      end
+
       it_behaves_like 'an authenticated resource'
       it_behaves_like 'an authorized resource' do
         let(:resource_permission) { delete_file_permission }
@@ -340,12 +384,13 @@ describe DDS::V1::RelationsAPI do
           creator: current_user,
           relatable_to: activity)
       }
+      let(:activity_for_deleted) { FactoryGirl.create(:activity, creator: current_user)}
       let(:deleted_associated_with_user_prov_relation) {
         FactoryGirl.create(:associated_with_user_prov_relation,
           is_deleted: true,
           relatable_from: current_user,
           creator: current_user,
-          relatable_to: activity)
+          relatable_to: activity_for_deleted)
       }
       let(:associated_with_software_agent_prov_relation) {
         FactoryGirl.create(:associated_with_software_agent_prov_relation,

--- a/spec/serializers/activity_serializer_spec.rb
+++ b/spec/serializers/activity_serializer_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 RSpec.describe ActivitySerializer, type: :serializer do
-  let(:resource) { FactoryGirl.create(:activity) }
+  let(:resource) { FactoryGirl.create(:activity,
+    started_on: 10.minutes.ago,
+    ended_on: DateTime.now
+  ) }
   let(:is_logically_deleted) { true }
 
   it_behaves_like 'a json serializer' do

--- a/spec/support/models_shared_examples.rb
+++ b/spec/support/models_shared_examples.rb
@@ -190,6 +190,11 @@ shared_examples 'a ProvRelation' do
     it { is_expected.to validate_presence_of :creator_id }
     it { is_expected.to validate_presence_of :relatable_from }
     it { is_expected.to validate_presence_of :relatable_to }
+    it {
+      is_expected.to validate_uniqueness_of(:relationship_type).scoped_to(
+        [:relatable_from_id, :relatable_to_id]
+      ).case_insensitive
+    }
   end
 
   it 'should implement set_relationship_type' do


### PR DESCRIPTION
ProvRelations all have a uniqueness constraint for relationship_type scoped to [relatable_from_id, relatable_to_id]

activity started_on defaults to DateTime.now
