### PR TITLE
DDS-482 rails5 preparation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'neo4j'
 gem 'puma'
 gem 'rack', '1.6.4' # Remove in rails 5
 gem 'rack-cors', :require => 'rack/cors'
+gem 'grape-middleware-lograge'
 
 gem 'grape-swagger'
 gem 'kaminari'


### PR DESCRIPTION
Mistakenly removed grape-middleware-lograge gem from Gemfile, which wasn't caught until after deployment of PR#692.
