### PR TITLE
auth_service_rake_spec expects auth_service.rake to implement auth_se…

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -45,6 +45,7 @@ deployment:
     - heroku run rake --exit-code db:migrate --app 'dukeds-dev'
     - heroku run rake --exit-code db:seed --app 'dukeds-dev'
     - heroku run --exit-code rake db:data:migrate --app 'dukeds-dev'
+    - heroku run --exit-code rake auth_service:set_default --app 'dukeds-dev'
     - heroku maintenance:off --app 'dukeds-dev'
  ua_test:
    branch: ua_test
@@ -57,6 +58,7 @@ deployment:
     - heroku run --exit-code rake db:migrate --app 'dukeds-uatest'
     - heroku run --exit-code rake db:seed --app 'dukeds-uatest'
     - heroku run --exit-code rake db:data:migrate --app 'dukeds-uatest'
+    - heroku run --exit-code rake auth_service:set_default --app 'dukeds-uatest'
     - heroku maintenance:off --app 'dukeds-uatest'
  production:
    branch: production
@@ -68,3 +70,4 @@ deployment:
     - heroku run --exit-code rake db:migrate --app 'dukeds'
     - heroku run --exit-code rake db:seed --app 'dukeds'
     - heroku run --exit-code rake db:data:migrate --app 'dukeds'
+    - heroku run --exit-code rake auth_service:set_default --app 'dukeds'

--- a/lib/tasks/auth_service.rake
+++ b/lib/tasks/auth_service.rake
@@ -40,10 +40,7 @@ namespace :auth_service do
       if existing_default_auth_service
         raise "Service #{existing_default_auth_service.service_id} is already default. Use auth_service_transfer_default instead"
       end
-
-      auth_service.transaction do
-        auth_service.update!(is_default: true)
-      end
+      auth_service.update!(is_default: true)
     end
   end
 


### PR DESCRIPTION
…rvice:set_default

  - takes ENV[AUTH_SERVICE_SERVICE_ID]
  - if it exists and there is no other default service, sets it as default
  - if it is already default prints message to stderr
  - if it does not exist, or there is another default service, raises exception
auth_service.rake meets spec

circle.yml runs rake auth_service:set_default on every deployment