### PR TITLE
application_job_spec

### DIFF
--- a/app/jobs/project_storage_provider_initialization_job.rb
+++ b/app/jobs/project_storage_provider_initialization_job.rb
@@ -1,5 +1,5 @@
 class ProjectStorageProviderInitializationJob < ApplicationJob
-  queue_as :default
+  queue_as self.name.underscore.gsub('_job','').to_sym
 
   def perform(storage_provider:, project:)
     storage_provider.put_container(project.id)

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ApplicationJob, type: :job do
   before do
     Sneakers.configure(exchange: gateway_exchange_name, timeout_job_after: 300, threads: 1)
   end
-  
+
   it { is_expected.to be_a ActiveJob::Base }
   it { expect{described_class.perform_now}.to raise_error(NotImplementedError) }
 
@@ -69,6 +69,7 @@ RSpec.describe ApplicationJob, type: :job do
         end
       end)
     }
+    it { expect(child_class.queue_name).to eq(child_class_queue_name) }
 
     it { expect{child_class.perform_now}.not_to raise_error }
     it { expect(child_class).to respond_to :run_count }

--- a/spec/jobs/project_storage_provider_initialization_job_spec.rb
+++ b/spec/jobs/project_storage_provider_initialization_job_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ProjectStorageProviderInitializationJob, type: :job do
   let(:project) { FactoryGirl.create(:project) }
   let!(:storage_provider) { FactoryGirl.create(:storage_provider, :swift) }
   it { is_expected.to be_an ApplicationJob }
+  it { expect(described_class.queue_name).to eq("project_storage_provider_initialization") }
 
   context 'perform_now', :vcr do
     it 'should require a project argument' do


### PR DESCRIPTION
- ensures that child_class.queue_name is set properly

project_storage_provider_initialization_job_spec expects
  project_storage_provider_initialization_job to use
  "project_storage_provider_initialization" as its queue
project_storage_provider_initialization_job passes spec