### PR TITLE
DDS-809 fix request timeout prod

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'puma'
 gem 'rack', '1.6.4' # Remove in rails 5
 gem 'rack-cors', :require => 'rack/cors'
 gem 'grape-middleware-lograge'
+gem "rack-timeout"
 
 gem 'grape-swagger'
 gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,6 +218,7 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
+    rack-timeout (0.4.2)
     rails (4.2.1)
       actionmailer (= 4.2.1)
       actionpack (= 4.2.1)
@@ -342,6 +343,7 @@ DEPENDENCIES
   pundit
   rack (= 1.6.4)
   rack-cors
+  rack-timeout
   rails (= 4.2.1)
   rails_12factor
   rspec-rails

--- a/app/api/dds/v1/base.rb
+++ b/app/api/dds/v1/base.rb
@@ -195,6 +195,15 @@ module DDS
         error!(error_json, 500)
       end
 
+      rescue_from Rack::Timeout::RequestTimeoutError do |e|
+        error_json = {
+          "error" => "503",
+          "reason" => 'Request Timeout',
+          "suggestion" => 'try again in a few minutes, or contact the systems administrators'
+        }
+        error!(error_json, 503)
+      end
+
       mount DDS::V1::UsersAPI
       mount DDS::V1::SystemPermissionsAPI
       mount DDS::V1::AppAPI

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,0 +1,4 @@
+Rack::Timeout.service_timeout = Integer(ENV['RACK_TIMEOUT_SERVICE_TIMEOUT']) if ENV.has_key?('RACK_TIMEOUT_SERVICE_TIMEOUT')
+Rack::Timeout.wait_timeout = Integer(ENV['RACK_TIMEOUT_WAIT_TIMEOUT']) if ENV.has_key?('RACK_TIMEOUT_WAIT_TIMEOUT')
+Rack::Timeout.wait_overtime = Integer(ENV['RACK_TIMEOUT_WAIT_OVERTIME']) if ENV.has_key?('RACK_TIMEOUT_WAIT_OVERTIME')
+Rack::Timeout.service_past_wait = (ENV['RACK_TIMEOUT_SERVICE_PAST_WAIT'] == 'true')

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,7 +1,6 @@
 workers Integer(ENV['WEB_CONCURRENCY'] || 2)
 threads_count = Integer(ENV['MAX_THREADS'] || 5)
 threads threads_count, threads_count
-worker_timeout Integer(ENV['WORKER_TIMEOUT']) if ENV['WORKER_TIMEOUT']
 
 preload_app!
 

--- a/spec/requests/base_spec.rb
+++ b/spec/requests/base_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe DDS::V1::Base do
+  let(:path) {"/api_base_test"}
+  let(:dummy) do
+    dummy_path = path
+    Class.new(Grape::API) do
+      helpers do
+        def override_helper; end
+      end
+      get dummy_path do
+        override_helper
+      end
+    end
+  end
+  before do
+    described_class.mount dummy
+  end
+
+  let(:url) {"/api/v1" + path }
+  subject { get(url) }
+
+  context 'when Rack::Timeout raises Rack::Timeout::RequestTimeoutError' do
+    before do
+      Grape::Endpoint.before_each do |endpoint|
+        expect(endpoint).to receive(:override_helper).and_raise(Rack::Timeout::RequestTimeoutError, ENV)
+      end
+    end
+    after { Grape::Endpoint.before_each nil }
+    it 'should return a 503' do
+      is_expected.to eq 503
+      expect(response.body).to include('Request Timeout')
+    end
+  end
+end

--- a/spec/requests/base_spec.rb
+++ b/spec/requests/base_spec.rb
@@ -15,6 +15,7 @@ describe DDS::V1::Base do
   end
   before do
     described_class.mount dummy
+    DDS::Base.change!
   end
 
   let(:url) {"/api/v1" + path }


### PR DESCRIPTION
The puma worker_timeout configuration only works in cluster mode, which I don't think our deployment uses:

http://www.rubydoc.info/github/puma/puma/Puma%2FConfiguration%2FDSL%3Aworker_timeout

We should use the Rack::Timeout gem as described here:

https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#timeout

https://github.com/heroku/rack-timeout/tree/v0.4.2