### PR TITLE
Bug Fix: random auth_provider test failures

### DIFF
--- a/app/models/ldap_identity_provider.rb
+++ b/app/models/ldap_identity_provider.rb
@@ -10,7 +10,7 @@ class LdapIdentityProvider < IdentityProvider
   end
 
   def affiliates(full_name_contains=nil)
-    return [] unless full_name_contains && full_name_contains.length > 3
+    return [] unless full_name_contains && full_name_contains.length >= 3
     ldap_search(
       Net::LDAP::Filter.construct("displayName=*#{full_name_contains}*")
     )

--- a/spec/models/ldap_identity_provider_spec.rb
+++ b/spec/models/ldap_identity_provider_spec.rb
@@ -45,6 +45,16 @@ RSpec.describe LdapIdentityProvider, type: :model do
         }
       end
 
+      context 'is 3 characters' do
+        let(:ldap_returns) { [test_user] }
+        include_context 'mocked ldap', returns: :ldap_returns
+        subject { auth_provider.identity_provider.affiliates('foo') }
+        it {
+          is_expected.to be_a Array
+          expect(subject.length).to be > 0
+        }
+      end
+
       context 'greater than 3 characters' do
         let(:ldap_returns) { [test_user] }
         include_context 'mocked ldap', returns: :ldap_returns


### PR DESCRIPTION
AuthProvider#affiliates allows full_name_contains to be 3 characters