### PR TITLE
DDS-835 message log worker

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -20,10 +20,8 @@ class ApplicationJob < ActiveJob::Base
         distributor_exchange_name, 
         type: distributor_exchange_type, durable: true
       )
-      message_log = channel.queue('message_log', durable: true)
 
       distributor.bind(gateway)
-      message_log.bind(gateway)
     end
   end
 

--- a/app/workers/message_log_worker.rb
+++ b/app/workers/message_log_worker.rb
@@ -3,5 +3,13 @@ class MessageLogWorker
   from_queue 'message_log'
 
   def work_with_params(msg, delivery_info, metadata)
+    Rails.logger.info({
+      MESSAGE_LOG: {
+        message: msg,
+        delivery_info: delivery_info,
+        metadata: metadata
+      }
+    }.to_json)
+    ack!
   end
 end

--- a/app/workers/message_log_worker.rb
+++ b/app/workers/message_log_worker.rb
@@ -1,0 +1,3 @@
+class MessageLogWorker
+  include Sneakers::Worker
+end

--- a/app/workers/message_log_worker.rb
+++ b/app/workers/message_log_worker.rb
@@ -1,3 +1,7 @@
 class MessageLogWorker
   include Sneakers::Worker
+  from_queue 'message_log'
+
+  def work_with_params(msg, delivery_info, metadata)
+  end
 end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe ApplicationJob, type: :job do
   let(:distributor_exchange_name) { 'active_jobs' }
   let(:distributor_exchange_type) { :direct }
   let(:distributor_exchange) { channel.exchange(distributor_exchange_name, type: distributor_exchange_type, durable: true) }
-  let(:message_log_name) { 'message_log' }
-  let(:message_log_queue) { channel.queue(message_log_name, durable: true) }
 
   let(:bunny_session) { Sneakers::CONFIG[:connection] }
   let(:channel) { bunny_session.channel }
@@ -21,9 +19,6 @@ RSpec.describe ApplicationJob, type: :job do
         channel.exchange_delete(gateway_exchange_name)
         channel.exchange_delete(distributor_exchange_name)
       end
-      if channel.respond_to? :queue_delete
-        channel.queue_delete(message_log_name)
-      end
     end
   end
 
@@ -35,7 +30,6 @@ RSpec.describe ApplicationJob, type: :job do
     let(:create_bindings) { described_class.create_bindings }
     it { expect(bunny_session.exchange_exists?(gateway_exchange_name)).to be_falsey }
     it { expect(bunny_session.exchange_exists?(distributor_exchange_name)).to be_falsey }
-    it { expect(bunny_session.queue_exists?(message_log_name)).to be_falsey }
     context 'once called' do
       before { create_bindings }
       it { expect(bunny_session.exchange_exists?(gateway_exchange_name)).to be_truthy }
@@ -46,11 +40,8 @@ RSpec.describe ApplicationJob, type: :job do
       it { expect(distributor_exchange.type).to eq(:direct) }
       it { expect(distributor_exchange).to be_durable }
 
-      it { expect(bunny_session.queue_exists?(message_log_name)).to be_truthy }
-      it { expect(message_log_queue).to be_durable }
 
       it { expect(distributor_exchange).to be_bound_to(gateway_exchange) }
-      it { expect(message_log_queue).to be_bound_to(gateway_exchange) }
     end
   end
 

--- a/spec/workers/message_log_worker_spec.rb
+++ b/spec/workers/message_log_worker_spec.rb
@@ -14,5 +14,27 @@ RSpec.describe MessageLogWorker do
   it { is_expected.to respond_to(:work_with_params).with(3).arguments }
 
   describe '#work_with_params' do
+    let(:message) { Faker::Lorem.words(5) }
+    let(:delivery_info) { {exchange: Faker::Internet.slug, id: Faker::Number.digit} }
+    let(:metadata) { :baz }
+    let(:method_call) { subject.work_with_params(message, delivery_info, metadata) }
+    let(:ack) { subject.ack! }
+    it { expect(ack).not_to be_nil }
+    it { expect(method_call).to eq ack }
+
+    context 'calls Rails.logger' do
+      let(:log_message) {{
+        MESSAGE_LOG: {
+          message: message,
+          delivery_info: delivery_info,
+          metadata: metadata
+        }
+      }.to_json}
+      before do
+        allow(Rails.logger).to receive(:info)
+        expect{method_call}.not_to raise_error
+      end
+      it { expect(Rails.logger).to have_received(:info).with(log_message) }
+    end
   end
 end

--- a/spec/workers/message_log_worker_spec.rb
+++ b/spec/workers/message_log_worker_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe MessageLogWorker do
+  it { expect(described_class).to include(Sneakers::Worker) }
+end

--- a/spec/workers/message_log_worker_spec.rb
+++ b/spec/workers/message_log_worker_spec.rb
@@ -22,19 +22,16 @@ RSpec.describe MessageLogWorker do
     it { expect(ack).not_to be_nil }
     it { expect(method_call).to eq ack }
 
-    context 'calls Rails.logger' do
-      let(:log_message) {{
-        MESSAGE_LOG: {
-          message: message,
-          delivery_info: delivery_info,
-          metadata: metadata
-        }
-      }.to_json}
-      before do
-        allow(Rails.logger).to receive(:info)
-        expect{method_call}.not_to raise_error
-      end
-      it { expect(Rails.logger).to have_received(:info).with(log_message) }
+    let(:log_message) {{
+      MESSAGE_LOG: {
+        message: message,
+        delivery_info: delivery_info,
+        metadata: metadata
+      }
+    }.to_json}
+    it 'calls Rails.logger' do
+      expect(Rails.logger).to receive(:info).with(log_message)
+      expect{method_call}.not_to raise_error
     end
   end
 end

--- a/spec/workers/message_log_worker_spec.rb
+++ b/spec/workers/message_log_worker_spec.rb
@@ -1,5 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe MessageLogWorker do
+  let(:gateway_exchange_name) { Sneakers::CONFIG[:exchange] }
+  let(:queue_name) { 'message_log' }
+
   it { expect(described_class).to include(Sneakers::Worker) }
+  it { expect(subject.queue.name).to eq(queue_name) }
+  it { expect(subject.opts[:exchange]).to eq(gateway_exchange_name) }
+  it { expect(subject.opts[:exchange_options][:type]).to eq(:fanout) }
+  it { expect(subject.opts[:exchange_options][:durable]).to be_truthy }
+
+  it { is_expected.not_to respond_to(:work) }
+  it { is_expected.to respond_to(:work_with_params).with(3).arguments }
+
+  describe '#work_with_params' do
+  end
 end


### PR DESCRIPTION
The MessageLogWorker takes messages off the 'message_log' queue and sends them to Rails.logger.info as a way of keeping a record of RabbitMQ messages, which will hopefully be useful for debugging purposes.