### PR TITLE
Remove unneeded call to Rails.application.eager_load!

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  config.eager_load = true
 
   # Configure static file server for tests with Cache-Control for performance.
   if Rails.version > '5.0.0'

--- a/lib/tasks/workers.rake
+++ b/lib/tasks/workers.rake
@@ -10,9 +10,6 @@ namespace :workers do
   namespace :initialize_project_storage do
     desc 'run a ProjectStorageProviderInitializationJob'
     task run: :environment do
-      silence_warnings do
-        Rails.application.eager_load! unless Rails.application.config.eager_load
-      end
       workers = [ ProjectStorageProviderInitializationJob.job_wrapper ]
       Sneakers::Runner.new(workers).run
     end
@@ -21,9 +18,6 @@ namespace :workers do
   namespace :delete_children do
     desc 'run a ChildDeletionJob'
     task run: :environment do
-      silence_warnings do
-        Rails.application.eager_load! unless Rails.application.config.eager_load
-      end
       workers = [ ChildDeletionJob.job_wrapper ]
       Sneakers::Runner.new(workers).run
     end
@@ -32,9 +26,6 @@ namespace :workers do
   namespace :index_documents do
     desc 'run an ElasticsearchIndexJob'
     task run: :environment do
-      silence_warnings do
-        Rails.application.eager_load! unless Rails.application.config.eager_load
-      end
       workers = [ ElasticsearchIndexJob.job_wrapper ]
       Sneakers::Runner.new(workers).run
     end

--- a/spec/cassettes/DDS_V1_AppAPI/app_status/queue/behaves_like_it_requires_queue/behaves_like_a_status_error/1_1_6_10_1_1.yml
+++ b/spec/cassettes/DDS_V1_AppAPI/app_status/queue/behaves_like_it_requires_queue/behaves_like_a_status_error/1_1_6_10_1_1.yml
@@ -1,0 +1,145 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://swift.local:12345/auth/v1.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-User:
+      - test:tester
+      X-Auth-Key:
+      - testing
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Storage-Url:
+      - http://swift.local:12345/v1/AUTH_test
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Storage-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Length:
+      - '0'
+      X-Trans-Id:
+      - txc29a162eadba475b93440-0058d08f50
+      Date:
+      - Tue, 21 Mar 2017 02:26:24 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:24 GMT
+- request:
+    method: post
+    uri: http://swift.local:12345/v1/AUTH_test
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      X-Account-Meta-Temp-Url-Key:
+      - 22a91bd2dfe18e04be2cfe387085bf47
+      X-Account-Meta-Temp-Url-Key-2:
+      - 6e844ad17e801101ca3d23db5e05e0ed
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Trans-Id:
+      - tx24f41dddd21a49598ba57-0058d08f50
+      Date:
+      - Tue, 21 Mar 2017 02:26:24 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:24 GMT
+- request:
+    method: get
+    uri: http://swift.local:12345/auth/v1.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-User:
+      - test:tester
+      X-Auth-Key:
+      - testing
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Storage-Url:
+      - http://swift.local:12345/v1/AUTH_test
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Storage-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Length:
+      - '0'
+      X-Trans-Id:
+      - txb486d5a64c2e46c9b4940-0058d08f50
+      Date:
+      - Tue, 21 Mar 2017 02:26:24 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:24 GMT
+- request:
+    method: get
+    uri: http://swift.local:12345/v1/AUTH_test
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Length:
+      - '0'
+      X-Account-Object-Count:
+      - '0'
+      X-Account-Meta-Temp-Url-Key-2:
+      - 6e844ad17e801101ca3d23db5e05e0ed
+      X-Timestamp:
+      - '1489588696.99804'
+      X-Account-Meta-Temp-Url-Key:
+      - 22a91bd2dfe18e04be2cfe387085bf47
+      X-Account-Bytes-Used:
+      - '0'
+      X-Account-Container-Count:
+      - '0'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Accept-Ranges:
+      - bytes
+      X-Trans-Id:
+      - txc1bdcd6334554ee19f724-0058d08f50
+      Date:
+      - Tue, 21 Mar 2017 02:26:24 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:24 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/DDS_V1_AppAPI/app_status/queue/behaves_like_it_requires_queue/behaves_like_a_status_error/1_1_6_11_1_1.yml
+++ b/spec/cassettes/DDS_V1_AppAPI/app_status/queue/behaves_like_it_requires_queue/behaves_like_a_status_error/1_1_6_11_1_1.yml
@@ -1,0 +1,145 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://swift.local:12345/auth/v1.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-User:
+      - test:tester
+      X-Auth-Key:
+      - testing
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Storage-Url:
+      - http://swift.local:12345/v1/AUTH_test
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Storage-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Length:
+      - '0'
+      X-Trans-Id:
+      - tx0d38337f1d34442383149-0058d08f50
+      Date:
+      - Tue, 21 Mar 2017 02:26:24 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:24 GMT
+- request:
+    method: post
+    uri: http://swift.local:12345/v1/AUTH_test
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      X-Account-Meta-Temp-Url-Key:
+      - f02bfb01e8a2c730df049ce243e59bb5
+      X-Account-Meta-Temp-Url-Key-2:
+      - 55a35996915923a3ce201a240aba6b4f
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Trans-Id:
+      - txb5c023eabcb5455fba58c-0058d08f50
+      Date:
+      - Tue, 21 Mar 2017 02:26:24 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:24 GMT
+- request:
+    method: get
+    uri: http://swift.local:12345/auth/v1.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-User:
+      - test:tester
+      X-Auth-Key:
+      - testing
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Storage-Url:
+      - http://swift.local:12345/v1/AUTH_test
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Storage-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Length:
+      - '0'
+      X-Trans-Id:
+      - tx97ce24fe2c214b59a2b4e-0058d08f50
+      Date:
+      - Tue, 21 Mar 2017 02:26:24 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:24 GMT
+- request:
+    method: get
+    uri: http://swift.local:12345/v1/AUTH_test
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Length:
+      - '0'
+      X-Account-Object-Count:
+      - '0'
+      X-Account-Meta-Temp-Url-Key-2:
+      - 55a35996915923a3ce201a240aba6b4f
+      X-Timestamp:
+      - '1489588696.99804'
+      X-Account-Meta-Temp-Url-Key:
+      - f02bfb01e8a2c730df049ce243e59bb5
+      X-Account-Bytes-Used:
+      - '0'
+      X-Account-Container-Count:
+      - '0'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Accept-Ranges:
+      - bytes
+      X-Trans-Id:
+      - txaea7c89fb05a443aa2edf-0058d08f50
+      Date:
+      - Tue, 21 Mar 2017 02:26:24 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:24 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/DDS_V1_AppAPI/app_status/queue/behaves_like_it_requires_queue/behaves_like_a_status_error/1_1_6_12_1_1.yml
+++ b/spec/cassettes/DDS_V1_AppAPI/app_status/queue/behaves_like_it_requires_queue/behaves_like_a_status_error/1_1_6_12_1_1.yml
@@ -1,0 +1,145 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://swift.local:12345/auth/v1.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-User:
+      - test:tester
+      X-Auth-Key:
+      - testing
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Storage-Url:
+      - http://swift.local:12345/v1/AUTH_test
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Storage-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Length:
+      - '0'
+      X-Trans-Id:
+      - tx832a18c3d296412cbae16-0058d08f50
+      Date:
+      - Tue, 21 Mar 2017 02:26:24 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:24 GMT
+- request:
+    method: post
+    uri: http://swift.local:12345/v1/AUTH_test
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      X-Account-Meta-Temp-Url-Key:
+      - ba092904aad240c568b0b05b7f9ee0fd
+      X-Account-Meta-Temp-Url-Key-2:
+      - cd0dd781301ad5f3cc522e03564026f1
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Trans-Id:
+      - tx50625e8d5e354518b3c4d-0058d08f50
+      Date:
+      - Tue, 21 Mar 2017 02:26:24 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:24 GMT
+- request:
+    method: get
+    uri: http://swift.local:12345/auth/v1.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-User:
+      - test:tester
+      X-Auth-Key:
+      - testing
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Storage-Url:
+      - http://swift.local:12345/v1/AUTH_test
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Storage-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Length:
+      - '0'
+      X-Trans-Id:
+      - tx0a08449f284549488702b-0058d08f50
+      Date:
+      - Tue, 21 Mar 2017 02:26:24 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:24 GMT
+- request:
+    method: get
+    uri: http://swift.local:12345/v1/AUTH_test
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Length:
+      - '0'
+      X-Account-Object-Count:
+      - '0'
+      X-Account-Meta-Temp-Url-Key-2:
+      - cd0dd781301ad5f3cc522e03564026f1
+      X-Timestamp:
+      - '1489588696.99804'
+      X-Account-Meta-Temp-Url-Key:
+      - ba092904aad240c568b0b05b7f9ee0fd
+      X-Account-Bytes-Used:
+      - '0'
+      X-Account-Container-Count:
+      - '0'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Accept-Ranges:
+      - bytes
+      X-Trans-Id:
+      - tx58ac881cef9149959ee89-0058d08f50
+      Date:
+      - Tue, 21 Mar 2017 02:26:24 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:24 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/DDS_V1_AppAPI/app_status/queue/behaves_like_it_requires_queue/behaves_like_a_status_error/1_1_6_13_1_1.yml
+++ b/spec/cassettes/DDS_V1_AppAPI/app_status/queue/behaves_like_it_requires_queue/behaves_like_a_status_error/1_1_6_13_1_1.yml
@@ -1,0 +1,145 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://swift.local:12345/auth/v1.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-User:
+      - test:tester
+      X-Auth-Key:
+      - testing
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Storage-Url:
+      - http://swift.local:12345/v1/AUTH_test
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Storage-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Length:
+      - '0'
+      X-Trans-Id:
+      - txe77bc921a7dd4cbab2635-0058d08f50
+      Date:
+      - Tue, 21 Mar 2017 02:26:24 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:24 GMT
+- request:
+    method: post
+    uri: http://swift.local:12345/v1/AUTH_test
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      X-Account-Meta-Temp-Url-Key:
+      - 9c3302f2be0d189532b3bf3bb79c79ee
+      X-Account-Meta-Temp-Url-Key-2:
+      - 301b9e6bedf24df623c2aa36de9784fa
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Trans-Id:
+      - txb3ba869ae5704d2abf2a2-0058d08f50
+      Date:
+      - Tue, 21 Mar 2017 02:26:25 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:25 GMT
+- request:
+    method: get
+    uri: http://swift.local:12345/auth/v1.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-User:
+      - test:tester
+      X-Auth-Key:
+      - testing
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Storage-Url:
+      - http://swift.local:12345/v1/AUTH_test
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Storage-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Length:
+      - '0'
+      X-Trans-Id:
+      - tx420c27f1c0e74f8fbfe4f-0058d08f51
+      Date:
+      - Tue, 21 Mar 2017 02:26:25 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:25 GMT
+- request:
+    method: get
+    uri: http://swift.local:12345/v1/AUTH_test
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Length:
+      - '0'
+      X-Account-Object-Count:
+      - '0'
+      X-Account-Meta-Temp-Url-Key-2:
+      - 301b9e6bedf24df623c2aa36de9784fa
+      X-Timestamp:
+      - '1489588696.99804'
+      X-Account-Meta-Temp-Url-Key:
+      - 9c3302f2be0d189532b3bf3bb79c79ee
+      X-Account-Bytes-Used:
+      - '0'
+      X-Account-Container-Count:
+      - '0'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Accept-Ranges:
+      - bytes
+      X-Trans-Id:
+      - tx56ab4c93a068422ab8115-0058d08f51
+      Date:
+      - Tue, 21 Mar 2017 02:26:25 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:25 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/DDS_V1_AppAPI/app_status/queue/behaves_like_it_requires_queue/behaves_like_a_status_error/1_1_6_14_1_1.yml
+++ b/spec/cassettes/DDS_V1_AppAPI/app_status/queue/behaves_like_it_requires_queue/behaves_like_a_status_error/1_1_6_14_1_1.yml
@@ -1,0 +1,145 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://swift.local:12345/auth/v1.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-User:
+      - test:tester
+      X-Auth-Key:
+      - testing
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Storage-Url:
+      - http://swift.local:12345/v1/AUTH_test
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Storage-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Length:
+      - '0'
+      X-Trans-Id:
+      - txde76c4eeecba498fafc5b-0058d08f51
+      Date:
+      - Tue, 21 Mar 2017 02:26:25 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:25 GMT
+- request:
+    method: post
+    uri: http://swift.local:12345/v1/AUTH_test
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      X-Account-Meta-Temp-Url-Key:
+      - 93e48b96f04eeb5f04df5b28f800af8c
+      X-Account-Meta-Temp-Url-Key-2:
+      - 42afd23a663b40b30c61898ce3491856
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Trans-Id:
+      - tx0cccdb27d0ef4c46849a3-0058d08f51
+      Date:
+      - Tue, 21 Mar 2017 02:26:25 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:25 GMT
+- request:
+    method: get
+    uri: http://swift.local:12345/auth/v1.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-User:
+      - test:tester
+      X-Auth-Key:
+      - testing
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Storage-Url:
+      - http://swift.local:12345/v1/AUTH_test
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Storage-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Length:
+      - '0'
+      X-Trans-Id:
+      - tx348f084eeb324122ab683-0058d08f51
+      Date:
+      - Tue, 21 Mar 2017 02:26:25 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:25 GMT
+- request:
+    method: get
+    uri: http://swift.local:12345/v1/AUTH_test
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Length:
+      - '0'
+      X-Account-Object-Count:
+      - '0'
+      X-Account-Meta-Temp-Url-Key-2:
+      - 42afd23a663b40b30c61898ce3491856
+      X-Timestamp:
+      - '1489588696.99804'
+      X-Account-Meta-Temp-Url-Key:
+      - 93e48b96f04eeb5f04df5b28f800af8c
+      X-Account-Bytes-Used:
+      - '0'
+      X-Account-Container-Count:
+      - '0'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Accept-Ranges:
+      - bytes
+      X-Trans-Id:
+      - tx950246911ac74958bd4cb-0058d08f51
+      Date:
+      - Tue, 21 Mar 2017 02:26:25 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:25 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/DDS_V1_AppAPI/app_status/queue/behaves_like_it_requires_queue/behaves_like_a_status_error/1_1_6_9_1_1.yml
+++ b/spec/cassettes/DDS_V1_AppAPI/app_status/queue/behaves_like_it_requires_queue/behaves_like_a_status_error/1_1_6_9_1_1.yml
@@ -1,0 +1,145 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://swift.local:12345/auth/v1.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-User:
+      - test:tester
+      X-Auth-Key:
+      - testing
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Storage-Url:
+      - http://swift.local:12345/v1/AUTH_test
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Storage-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Length:
+      - '0'
+      X-Trans-Id:
+      - txe927a8df64e245f792af6-0058d08f4f
+      Date:
+      - Tue, 21 Mar 2017 02:26:23 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:23 GMT
+- request:
+    method: post
+    uri: http://swift.local:12345/v1/AUTH_test
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      X-Account-Meta-Temp-Url-Key:
+      - 71e4575b72e0ec2795e1519f93922215
+      X-Account-Meta-Temp-Url-Key-2:
+      - a0d739431e20dfd78d083a19ccebfe63
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Trans-Id:
+      - tx8ad245af47c949f6816f4-0058d08f4f
+      Date:
+      - Tue, 21 Mar 2017 02:26:24 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:24 GMT
+- request:
+    method: get
+    uri: http://swift.local:12345/auth/v1.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-User:
+      - test:tester
+      X-Auth-Key:
+      - testing
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Storage-Url:
+      - http://swift.local:12345/v1/AUTH_test
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Storage-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+      Content-Length:
+      - '0'
+      X-Trans-Id:
+      - txa1709e235c8f48f1b6e81-0058d08f50
+      Date:
+      - Tue, 21 Mar 2017 02:26:24 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:24 GMT
+- request:
+    method: get
+    uri: http://swift.local:12345/v1/AUTH_test
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Auth-Token:
+      - AUTH_tk54625d3066bc4151b56314a997a4883c
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Length:
+      - '0'
+      X-Account-Object-Count:
+      - '0'
+      X-Account-Meta-Temp-Url-Key-2:
+      - a0d739431e20dfd78d083a19ccebfe63
+      X-Timestamp:
+      - '1489588696.99804'
+      X-Account-Meta-Temp-Url-Key:
+      - 71e4575b72e0ec2795e1519f93922215
+      X-Account-Bytes-Used:
+      - '0'
+      X-Account-Container-Count:
+      - '0'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Accept-Ranges:
+      - bytes
+      X-Trans-Id:
+      - tx7d5c9b85f6ab4572ab22b-0058d08f50
+      Date:
+      - Tue, 21 Mar 2017 02:26:24 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Mar 2017 02:26:24 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/app_api_spec.rb
+++ b/spec/requests/app_api_spec.rb
@@ -178,5 +178,7 @@ describe DDS::V1::AppAPI do
         it_behaves_like 'it requires queue', :job_queue
       end
     end
+
+    it { expect(ApplicationJob.descendants).not_to be_empty }
   end #app status
 end


### PR DESCRIPTION
This removes unneeded calls to `Rails.application.eager_load!` from the job rake tasks. The `eager_load!` calls were necessary when iterating over the descendants of a class (like `ApplicationJob.descendants`), but not when calling those descendants by name.

Unfortunately, the `/app/status` endpoint and specs use `ApplicationJob.descendants` to test for RabbitMQ queue presence, which requires eager loading to work properly. So, in order to get predictable test results, I enabled eager loading in the rails test environment config. Incidentally, the production environment is configured to eager load by default, so I think this will lead to fewer deployment surprises down the road.