### PR TITLE
DDS-864 refactor background job workers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,5 @@
 web: bundle exec puma -C config/puma.rb
+all_workers: bundle exec rake workers:all:run
 message_log_worker: bundle exec rake workers:message_logger:run
 project_storage_init_job: bundle exec rake workers:initialize_project_storage:run
 child_deletion_job: bundle exec rake workers:delete_children:run

--- a/app/services/jobs_runner.rb
+++ b/app/services/jobs_runner.rb
@@ -1,0 +1,11 @@
+require 'sneakers/runner'
+
+class JobsRunner
+  def initialize(job_class_or_array)
+    @job = job_class_or_array
+  end
+
+  def run
+    Sneakers::Runner.new([@job]).run
+  end
+end

--- a/app/services/jobs_runner.rb
+++ b/app/services/jobs_runner.rb
@@ -19,6 +19,10 @@ class JobsRunner
     }
   end
 
+  def self.all
+    self.new(self.workers_registry.values)
+  end
+
   private
 
   def normalize_job(job)

--- a/app/services/jobs_runner.rb
+++ b/app/services/jobs_runner.rb
@@ -3,13 +3,7 @@ require 'sneakers/runner'
 class JobsRunner
   def initialize(job_class_or_array)
     @jobs = [job_class_or_array].flatten
-    @jobs = @jobs.collect do |job|
-      if job < ApplicationJob
-        job.job_wrapper
-      else
-        job
-      end
-    end
+    @jobs = @jobs.collect(&method(:normalize_job))
   end
 
   def run
@@ -23,5 +17,15 @@ class JobsRunner
       delete_children: ChildDeletionJob,
       index_documents: ElasticsearchIndexJob
     }
+  end
+
+  private
+
+  def normalize_job(job)
+    if job < ApplicationJob
+      job.job_wrapper
+    else
+      job
+    end
   end
 end

--- a/app/services/jobs_runner.rb
+++ b/app/services/jobs_runner.rb
@@ -2,10 +2,10 @@ require 'sneakers/runner'
 
 class JobsRunner
   def initialize(job_class_or_array)
-    @job = job_class_or_array
+    @jobs = [job_class_or_array].flatten
   end
 
   def run
-    Sneakers::Runner.new([@job]).run
+    Sneakers::Runner.new(@jobs).run
   end
 end

--- a/app/services/jobs_runner.rb
+++ b/app/services/jobs_runner.rb
@@ -21,11 +21,15 @@ class JobsRunner
 
   def self.all(except: [])
     raise ArgumentError.new("keyword :except must be an array") unless except.is_a? Array
-    pruned_registry = self.workers_registry.reject {|k,v| except.include?(k)}
-    self.new(pruned_registry.values)
+    self.new(self.pruned_registry(except).values)
   end
 
   private
+
+  def self.pruned_registry(except)
+    except = except.collect &:to_s
+    self.workers_registry.reject {|k,v| except.include?(k.to_s)}
+  end
 
   def normalize_job(job)
     if job < ApplicationJob

--- a/app/services/jobs_runner.rb
+++ b/app/services/jobs_runner.rb
@@ -8,4 +8,13 @@ class JobsRunner
   def run
     Sneakers::Runner.new(@jobs).run
   end
+
+  def self.workers_registry
+    {
+      message_logger: MessageLogWorker,
+      initialize_project_storage: ProjectStorageProviderInitializationJob,
+      delete_children: ChildDeletionJob,
+      index_documents: ElasticsearchIndexJob
+    }
+  end
 end

--- a/app/services/jobs_runner.rb
+++ b/app/services/jobs_runner.rb
@@ -19,8 +19,10 @@ class JobsRunner
     }
   end
 
-  def self.all
-    self.new(self.workers_registry.values)
+  def self.all(except: [])
+    raise ArgumentError.new("keyword :except must be an array") unless except.is_a? Array
+    pruned_registry = self.workers_registry.reject {|k,v| except.include?(k)}
+    self.new(pruned_registry.values)
   end
 
   private

--- a/app/services/jobs_runner.rb
+++ b/app/services/jobs_runner.rb
@@ -3,6 +3,13 @@ require 'sneakers/runner'
 class JobsRunner
   def initialize(job_class_or_array)
     @jobs = [job_class_or_array].flatten
+    @jobs = @jobs.collect do |job|
+      if job < ApplicationJob
+        job.job_wrapper
+      else
+        job
+      end
+    end
   end
 
   def run

--- a/lib/tasks/workers.rake
+++ b/lib/tasks/workers.rake
@@ -1,30 +1,11 @@
 require 'sneakers/runner'
 namespace :workers do
-  namespace :message_logger do
-    desc 'run a MessageLogWorker'
-    task run: :environment do
-      JobsRunner.new(MessageLogWorker).run
-    end
-  end
-
-  namespace :initialize_project_storage do
-    desc 'run a ProjectStorageProviderInitializationJob'
-    task run: :environment do
-      JobsRunner.new(ProjectStorageProviderInitializationJob).run
-    end
-  end
-
-  namespace :delete_children do
-    desc 'run a ChildDeletionJob'
-    task run: :environment do
-      JobsRunner.new(ChildDeletionJob).run
-    end
-  end
-
-  namespace :index_documents do
-    desc 'run an ElasticsearchIndexJob'
-    task run: :environment do
-      JobsRunner.new(ElasticsearchIndexJob).run
+  JobsRunner.workers_registry.each do |worker_key, worker_class|
+    namespace worker_key do
+      desc "run an #{worker_class}"
+      task run: :environment do
+        JobsRunner.new(worker_class).run
+      end
     end
   end
 

--- a/lib/tasks/workers.rake
+++ b/lib/tasks/workers.rake
@@ -27,4 +27,11 @@ namespace :workers do
       JobsRunner.new(ElasticsearchIndexJob).run
     end
   end
+
+  namespace :all do
+    desc 'run all jobs'
+    task run: :environment do
+      JobsRunner.all.run
+    end
+  end
 end

--- a/lib/tasks/workers.rake
+++ b/lib/tasks/workers.rake
@@ -31,7 +31,8 @@ namespace :workers do
   namespace :all do
     desc 'run all jobs'
     task run: :environment do
-      JobsRunner.all.run
+      skip_workers = (ENV['WORKERS_ALL_RUN_EXCEPT']||'').gsub(' ','').split(',')
+      JobsRunner.all(except: skip_workers).run
     end
   end
 end

--- a/lib/tasks/workers.rake
+++ b/lib/tasks/workers.rake
@@ -10,21 +10,21 @@ namespace :workers do
   namespace :initialize_project_storage do
     desc 'run a ProjectStorageProviderInitializationJob'
     task run: :environment do
-      JobsRunner.new(ProjectStorageProviderInitializationJob.job_wrapper).run
+      JobsRunner.new(ProjectStorageProviderInitializationJob).run
     end
   end
 
   namespace :delete_children do
     desc 'run a ChildDeletionJob'
     task run: :environment do
-      JobsRunner.new(ChildDeletionJob.job_wrapper).run
+      JobsRunner.new(ChildDeletionJob).run
     end
   end
 
   namespace :index_documents do
     desc 'run an ElasticsearchIndexJob'
     task run: :environment do
-      JobsRunner.new(ElasticsearchIndexJob.job_wrapper).run
+      JobsRunner.new(ElasticsearchIndexJob).run
     end
   end
 end

--- a/lib/tasks/workers.rake
+++ b/lib/tasks/workers.rake
@@ -3,31 +3,28 @@ namespace :workers do
   namespace :message_logger do
     desc 'run a MessageLogWorker'
     task run: :environment do
-      Sneakers::Runner.new([MessageLogWorker]).run
+      JobsRunner.new(MessageLogWorker).run
     end
   end
 
   namespace :initialize_project_storage do
     desc 'run a ProjectStorageProviderInitializationJob'
     task run: :environment do
-      workers = [ ProjectStorageProviderInitializationJob.job_wrapper ]
-      Sneakers::Runner.new(workers).run
+      JobsRunner.new(ProjectStorageProviderInitializationJob.job_wrapper).run
     end
   end
 
   namespace :delete_children do
     desc 'run a ChildDeletionJob'
     task run: :environment do
-      workers = [ ChildDeletionJob.job_wrapper ]
-      Sneakers::Runner.new(workers).run
+      JobsRunner.new(ChildDeletionJob.job_wrapper).run
     end
   end
 
   namespace :index_documents do
     desc 'run an ElasticsearchIndexJob'
     task run: :environment do
-      workers = [ ElasticsearchIndexJob.job_wrapper ]
-      Sneakers::Runner.new(workers).run
+      JobsRunner.new(ElasticsearchIndexJob.job_wrapper).run
     end
   end
 end

--- a/lib/tasks/workers.rake
+++ b/lib/tasks/workers.rake
@@ -1,11 +1,30 @@
 require 'sneakers/runner'
 namespace :workers do
-  JobsRunner.workers_registry.each do |worker_key, worker_class|
-    namespace worker_key do
-      desc "run an #{worker_class}"
-      task run: :environment do
-        JobsRunner.new(worker_class).run
-      end
+  namespace :message_logger do
+    desc 'run a MessageLogWorker'
+    task run: :environment do
+      JobsRunner.new(MessageLogWorker).run
+    end
+  end
+
+  namespace :initialize_project_storage do
+    desc 'run a ProjectStorageProviderInitializationJob'
+    task run: :environment do
+      JobsRunner.new(ProjectStorageProviderInitializationJob).run
+    end
+  end
+
+  namespace :delete_children do
+    desc 'run a ChildDeletionJob'
+    task run: :environment do
+      JobsRunner.new(ChildDeletionJob).run
+    end
+  end
+
+  namespace :index_documents do
+    desc 'run an ElasticsearchIndexJob'
+    task run: :environment do
+      JobsRunner.new(ElasticsearchIndexJob).run
     end
   end
 

--- a/spec/lib/tasks/workers_rake_spec.rb
+++ b/spec/lib/tasks/workers_rake_spec.rb
@@ -51,5 +51,27 @@ describe "workers" do
       expect(mocked_jobs_runner).to receive(:run).and_return(true)
       invoke_task
     }
+
+    context "with ENV['WORKERS_ALL_RUN_EXCEPT'] set" do
+      let(:except_workers_array) {['index_documents', 'message_logger']}
+
+      before do
+        stub_const('ENV', {'WORKERS_ALL_RUN_EXCEPT' => except_workers_string})
+        expect(JobsRunner).to receive(:all)
+          .with(except: except_workers_array)
+          .and_return(mocked_jobs_runner)
+        expect(mocked_jobs_runner).to receive(:run).and_return(true)
+      end
+
+      context 'comma separated without spaces' do
+        let(:except_workers_string) { "%s,%s" % except_workers_array }
+        it { invoke_task }
+      end
+
+      context 'comma separated with spaces' do
+        let(:except_workers_string) { " %s,  %s " % except_workers_array }
+        it { invoke_task }
+      end
+    end
   end
 end

--- a/spec/lib/tasks/workers_rake_spec.rb
+++ b/spec/lib/tasks/workers_rake_spec.rb
@@ -38,4 +38,18 @@ describe "workers" do
     it { expect(subject.prerequisites).to  include("environment") }
     it_behaves_like 'a queued job worker', :expected_job_class
   end
+
+  describe 'workers:all:run' do
+    include_context "rake"
+    let(:task_name) { "workers:all:run" }
+    let(:mocked_jobs_runner) { instance_double(JobsRunner) }
+
+    it { expect(subject.prerequisites).to  include("environment") }
+    it {
+      expect(JobsRunner).to receive(:all)
+        .and_return(mocked_jobs_runner)
+      expect(mocked_jobs_runner).to receive(:run).and_return(true)
+      invoke_task
+    }
+  end
 end

--- a/spec/lib/tasks/workers_rake_spec.rb
+++ b/spec/lib/tasks/workers_rake_spec.rb
@@ -39,6 +39,24 @@ describe "workers" do
     it_behaves_like 'a queued job worker', :expected_job_class
   end
 
+  JobsRunner.workers_registry.each do |worker_key, worker_class|
+    describe "workers:#{worker_key}:run" do
+      include_context "rake"
+      let(:task_name) { "workers:#{worker_key}:run" }
+      let(:expected_job_class) { worker_class }
+
+      it { expect(subject.prerequisites).to  include("environment") }
+      it "calls JobsRunner#run with #{worker_class}" do
+        mocked_jobs_runner = instance_double(JobsRunner)
+        expect(JobsRunner).to receive(:new)
+          .with(worker_class)
+          .and_return(mocked_jobs_runner)
+        expect(mocked_jobs_runner).to receive(:run).and_return(true)
+        invoke_task
+      end
+    end
+  end
+
   describe 'workers:all:run' do
     include_context "rake"
     let(:task_name) { "workers:all:run" }

--- a/spec/services/jobs_runner_spec.rb
+++ b/spec/services/jobs_runner_spec.rb
@@ -6,7 +6,14 @@ RSpec.describe JobsRunner do
   let(:sneakers_worker) { Class.new { include Sneakers::Worker } }
   let(:mocked_sneakers_runner) { instance_double(Sneakers::Runner) }
   let(:application_job_class) { Class.new(ApplicationJob) }
-  let(:job_wrapper) { application_job_class.job_wrapper }
+
+  shared_context 'with job_wrapper' do
+    let(:job_wrapper) { application_job_class.job_wrapper }
+    before do
+      expect(application_job_class).to receive(:job_wrapper)
+        .and_return(job_wrapper)
+    end
+  end
 
   include_context 'with sneakers'
 
@@ -23,10 +30,9 @@ RSpec.describe JobsRunner do
 
     context 'when initialized with an ApplicationJob' do
       let(:initialized_with) { application_job_class }
+      include_context 'with job_wrapper'
 
       it 'runs the ApplicationJob::job_wrapper with Sneakers::Runner' do
-        expect(application_job_class).to receive(:job_wrapper)
-          .and_return(job_wrapper)
         expect(Sneakers::Runner).to receive(:new)
           .with([job_wrapper])
           .and_return(mocked_sneakers_runner)
@@ -38,10 +44,9 @@ RSpec.describe JobsRunner do
     context 'when initialized with an Array' do
       let(:another_sneakers_worker) { Class.new { include Sneakers::Worker } }
       let(:initialized_with) { [sneakers_worker, another_sneakers_worker, application_job_class] }
+      include_context 'with job_wrapper'
 
       it 'runs both jobs with Sneakers::Runner' do
-        expect(application_job_class).to receive(:job_wrapper)
-          .and_return(job_wrapper)
         expect(Sneakers::Runner).to receive(:new)
           .with([sneakers_worker, another_sneakers_worker, job_wrapper])
           .and_return(mocked_sneakers_runner)

--- a/spec/services/jobs_runner_spec.rb
+++ b/spec/services/jobs_runner_spec.rb
@@ -47,6 +47,12 @@ RSpec.describe JobsRunner do
           .with(permitted_worker_classes)
         expect{described_class.all(except: [except_worker_key])}.not_to raise_error
       end
+
+      it 'omit registered worker associated to string in :execpt array' do
+        expect(described_class).to receive(:new)
+          .with(permitted_worker_classes)
+        expect{described_class.all(except: [except_worker_key.to_s])}.not_to raise_error
+      end
     end
   end
 

--- a/spec/services/jobs_runner_spec.rb
+++ b/spec/services/jobs_runner_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe JobsRunner do
   let(:sneakers_worker) { Class.new { include Sneakers::Worker } }
   let(:mocked_sneakers_runner) { instance_double(Sneakers::Runner) }
 
+  include_context 'with sneakers'
+
   describe '#run' do
     it { is_expected.to respond_to(:run) }
 

--- a/spec/services/jobs_runner_spec.rb
+++ b/spec/services/jobs_runner_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe JobsRunner do
   let(:sneakers_worker) { Class.new { include Sneakers::Worker } }
   let(:mocked_sneakers_runner) { instance_double(Sneakers::Runner) }
   let(:application_job_class) { Class.new(ApplicationJob) }
+  let(:registered_worker_classes) {[
+    MessageLogWorker,
+    ProjectStorageProviderInitializationJob,
+    ChildDeletionJob,
+    ElasticsearchIndexJob
+  ]}
 
   shared_context 'with job_wrapper' do
     let(:job_wrapper) { application_job_class.job_wrapper }
@@ -16,6 +22,16 @@ RSpec.describe JobsRunner do
   end
 
   include_context 'with sneakers'
+
+  describe '::all' do
+    it { expect(described_class).to respond_to(:all) }
+    it { expect(described_class.all).to be_a described_class }
+    it 'calls ::new with Array of registered worker classes' do
+      expect(described_class).to receive(:new)
+        .with(registered_worker_classes)
+      expect{described_class.all}.not_to raise_error
+    end
+  end
 
   describe '#run' do
     it { is_expected.to respond_to(:run) }

--- a/spec/services/jobs_runner_spec.rb
+++ b/spec/services/jobs_runner_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe JobsRunner do
   let(:initialized_with) { sneakers_worker }
   let(:sneakers_worker) { Class.new { include Sneakers::Worker } }
   let(:mocked_sneakers_runner) { instance_double(Sneakers::Runner) }
+  let(:application_job_class) { Class.new(ApplicationJob) }
+  let(:job_wrapper) { application_job_class.job_wrapper }
 
   include_context 'with sneakers'
 
@@ -17,6 +19,20 @@ RSpec.describe JobsRunner do
         .and_return(mocked_sneakers_runner)
       expect(mocked_sneakers_runner).to receive(:run).and_return(true)
       expect{subject.run}.not_to raise_error
+    end
+
+    context 'when initialized with an ApplicationJob' do
+      let(:initialized_with) { application_job_class }
+
+      it 'runs the ApplicationJob::job_wrapper with Sneakers::Runner' do
+        expect(application_job_class).to receive(:job_wrapper)
+          .and_return(job_wrapper)
+        expect(Sneakers::Runner).to receive(:new)
+          .with([job_wrapper])
+          .and_return(mocked_sneakers_runner)
+        expect(mocked_sneakers_runner).to receive(:run).and_return(true)
+        expect{subject.run}.not_to raise_error
+      end
     end
 
     context 'when initialized with an Array' do

--- a/spec/services/jobs_runner_spec.rb
+++ b/spec/services/jobs_runner_spec.rb
@@ -32,6 +32,22 @@ RSpec.describe JobsRunner do
         .with(registered_worker_classes)
       expect{described_class.all}.not_to raise_error
     end
+
+    context 'with :except keyword' do
+      let(:except_worker_key) { workers_registry_hash.keys.sample }
+      let(:except_worker_class) { workers_registry_hash[except_worker_key] }
+      let(:permitted_worker_classes) { registered_worker_classes - [except_worker_class] }
+
+      it 'raises an ArgumentError when except is not an array' do
+        expect{described_class.all(except: except_worker_key)}.to raise_error(ArgumentError, 'keyword :except must be an array')
+      end
+
+      it 'omit registered worker associated to sym in :execpt array' do
+        expect(described_class).to receive(:new)
+          .with(permitted_worker_classes)
+        expect{described_class.all(except: [except_worker_key])}.not_to raise_error
+      end
+    end
   end
 
   describe '#run' do

--- a/spec/services/jobs_runner_spec.rb
+++ b/spec/services/jobs_runner_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe JobsRunner do
   let(:sneakers_worker) { Class.new { include Sneakers::Worker } }
   let(:mocked_sneakers_runner) { instance_double(Sneakers::Runner) }
   let(:application_job_class) { Class.new(ApplicationJob) }
-  let(:registered_worker_classes) {[
-    MessageLogWorker,
-    ProjectStorageProviderInitializationJob,
-    ChildDeletionJob,
-    ElasticsearchIndexJob
-  ]}
+  let(:workers_registry_hash) { {
+    message_logger: MessageLogWorker,
+    initialize_project_storage: ProjectStorageProviderInitializationJob,
+    delete_children: ChildDeletionJob,
+    index_documents: ElasticsearchIndexJob
+  } }
+  let(:registered_worker_classes) { workers_registry_hash.values }
 
   shared_context 'with job_wrapper' do
     let(:job_wrapper) { application_job_class.job_wrapper }
@@ -76,12 +77,7 @@ RSpec.describe JobsRunner do
     it { expect(described_class).to respond_to(:workers_registry) }
     it { expect(described_class.workers_registry).to be_a Hash }
     it {
-      expect(described_class.workers_registry).to eq({
-        message_logger: MessageLogWorker,
-        initialize_project_storage: ProjectStorageProviderInitializationJob,
-        delete_children: ChildDeletionJob,
-        index_documents: ElasticsearchIndexJob
-      })
+      expect(described_class.workers_registry).to eq(workers_registry_hash)
     }
   end
 end

--- a/spec/services/jobs_runner_spec.rb
+++ b/spec/services/jobs_runner_spec.rb
@@ -30,4 +30,17 @@ RSpec.describe JobsRunner do
       end
     end
   end
+
+  describe '::workers_registry' do
+    it { expect(described_class).to respond_to(:workers_registry) }
+    it { expect(described_class.workers_registry).to be_a Hash }
+    it {
+      expect(described_class.workers_registry).to eq({
+        message_logger: MessageLogWorker,
+        initialize_project_storage: ProjectStorageProviderInitializationJob,
+        delete_children: ChildDeletionJob,
+        index_documents: ElasticsearchIndexJob
+      })
+    }
+  end
 end

--- a/spec/services/jobs_runner_spec.rb
+++ b/spec/services/jobs_runner_spec.rb
@@ -16,5 +16,18 @@ RSpec.describe JobsRunner do
       expect(mocked_sneakers_runner).to receive(:run).and_return(true)
       expect{subject.run}.not_to raise_error
     end
+
+    context 'when initialized with an Array' do
+      let(:another_sneakers_worker) { Class.new { include Sneakers::Worker } }
+      let(:initialized_with) { [sneakers_worker, another_sneakers_worker] }
+
+      it 'runs both jobs with Sneakers::Runner' do
+        expect(Sneakers::Runner).to receive(:new)
+          .with([sneakers_worker, another_sneakers_worker])
+          .and_return(mocked_sneakers_runner)
+        expect(mocked_sneakers_runner).to receive(:run).and_return(true)
+        expect{subject.run}.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/services/jobs_runner_spec.rb
+++ b/spec/services/jobs_runner_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe JobsRunner do
+  subject { described_class.new(initialized_with) }
+  let(:initialized_with) { sneakers_worker }
+  let(:sneakers_worker) { Class.new { include Sneakers::Worker } }
+  let(:mocked_sneakers_runner) { instance_double(Sneakers::Runner) }
+
+  describe '#run' do
+    it { is_expected.to respond_to(:run) }
+
+    it 'runs the job with Sneakers::Runner' do
+      expect(Sneakers::Runner).to receive(:new)
+        .with([sneakers_worker])
+        .and_return(mocked_sneakers_runner)
+      expect(mocked_sneakers_runner).to receive(:run).and_return(true)
+      expect{subject.run}.not_to raise_error
+    end
+  end
+end

--- a/spec/services/jobs_runner_spec.rb
+++ b/spec/services/jobs_runner_spec.rb
@@ -37,11 +37,13 @@ RSpec.describe JobsRunner do
 
     context 'when initialized with an Array' do
       let(:another_sneakers_worker) { Class.new { include Sneakers::Worker } }
-      let(:initialized_with) { [sneakers_worker, another_sneakers_worker] }
+      let(:initialized_with) { [sneakers_worker, another_sneakers_worker, application_job_class] }
 
       it 'runs both jobs with Sneakers::Runner' do
+        expect(application_job_class).to receive(:job_wrapper)
+          .and_return(job_wrapper)
         expect(Sneakers::Runner).to receive(:new)
-          .with([sneakers_worker, another_sneakers_worker])
+          .with([sneakers_worker, another_sneakers_worker, job_wrapper])
           .and_return(mocked_sneakers_runner)
         expect(mocked_sneakers_runner).to receive(:run).and_return(true)
         expect{subject.run}.not_to raise_error


### PR DESCRIPTION
Moving the logic for running jobs into a separate class "that we own", which will make mocking tests much more sane. This new class, `JobsRunner`, will keep track of all our jobs in a `workers_registry` hash, which is used in dynamically creating rake tasks for each job as well as in its own `::all` method. Currently `JobsRunner` is tied to `Sneakers::Runner`, but this could easily be teased out into a module in order to support different queue adapters.