### PR TITLE
DDS-866-remove_vhost

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -58,7 +58,7 @@ class ApplicationJob < ActiveJob::Base
   end
 
   def self.conn
-    conn = opts[:connection] || Bunny.new(opts[:amqp], :vhost => opts[:vhost], :heartbeat => opts[:heartbeat], :logger => Sneakers::logger)
+    conn = opts[:connection]
     conn.start
   end
 end

--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -12,7 +12,6 @@ Sneakers.configure(
 )
 Sneakers.configure(
   connection: Bunny.new( ENV['CLOUDAMQP_URL'],
-    :vhost => Sneakers::CONFIG[:vhost],
     :heartbeat => Sneakers::CONFIG[:heartbeat],
     :logger => Sneakers::logger
   )


### PR DESCRIPTION
 removing vhost bunny configuration, as it sets it automatically from the ENV['CLOUDAMQP_URL']