### PR TITLE
DDS-880 bunny channel close bug

### DIFF
--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -58,7 +58,8 @@ module ActiveJob
     class SneakersAdapter
       class JobWrapper #:nodoc:
         def self.publisher
-          Sneakers::Publisher.new(queue_opts)
+          @publisher ||= {}
+          @publisher[queue_name] ||= Sneakers::Publisher.new(queue_opts)
         end
       end
     end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -78,7 +78,12 @@ RSpec.describe ApplicationJob, type: :job do
     let(:error_exchange_name) { 'active_jobs-error' }
     let(:retry_queue_name) { retry_exchange_name }
     let(:error_queue_name) { error_exchange_name }
-    let(:child_class_queue) { channel.queue(prefixed_queue_name, durable: true) }
+    let(:child_class_queue) {
+      channel.queue(prefixed_queue_name,
+        durable: true,
+        arguments: {'x-dead-letter-exchange': "#{child_class.queue_name}-retry"}
+      )
+    }
     let(:child_class_name) { "#{Faker::Internet.slug(nil, '_')}_job".classify }
     let(:child_class) {
       klass_queue_name = child_class_queue_name

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -190,6 +190,16 @@ RSpec.describe ApplicationJob, type: :job do
         context 'when stopped' do
           before { job_wrapper_instance.stop }
           it { expect{child_class.perform_later}.to change{child_class_queue.message_count}.by(1) }
+          context 'creates a one Sneakers::Publisher' do
+            before { expect(Sneakers::Publisher).to receive(:new).and_call_original }
+            it 'when called once' do
+              expect{child_class.perform_later}.not_to raise_error
+            end
+            it 'when called twice' do
+              expect{child_class.perform_later}.not_to raise_error
+              expect{child_class.perform_later}.not_to raise_error
+            end
+          end
         end
       end
     end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe ApplicationJob, type: :job do
         context 'when stopped' do
           before { job_wrapper_instance.stop }
           it { expect{child_class.perform_later}.to change{child_class_queue.message_count}.by(1) }
-          context 'creates a one Sneakers::Publisher' do
+          context 'creates one Sneakers::Publisher' do
             before { expect(Sneakers::Publisher).to receive(:new).and_call_original }
             it 'when called once' do
               expect{child_class.perform_later}.not_to raise_error


### PR DESCRIPTION
Creating a class instance hash to store one Sneakers::Publisher per queue_name, which should amount to one RabbitMQ channel per ApplicationJob subclass. Hopefully this will stop the channel sprawl that we were seeing, where a new channel was opened (and not closed) for each enqueued job.