### PR TITLE
Background Job bug fix (v1.3.13) to ua_test

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -4,7 +4,8 @@ class ApplicationJob < ActiveJob::Base
   class QueueNotFound < ::StandardError
   end
   before_enqueue do |job|
-    if self.class.queue_adapter.is_a?(ActiveJob::QueueAdapters::SneakersAdapter) &&
+    if ENV['SNEAKERS_SKIP_QUEUE_EXISTS_TEST'].nil? &&
+        self.class.queue_adapter.is_a?(ActiveJob::QueueAdapters::SneakersAdapter) &&
         !ApplicationJob.conn.queue_exists?(queue_name)
 
       raise QueueNotFound.new("Queue #{queue_name} does not exist")

--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -58,7 +58,8 @@ module ActiveJob
     class SneakersAdapter
       class JobWrapper #:nodoc:
         def self.publisher
-          Sneakers::Publisher.new(queue_opts)
+          @publisher ||= {}
+          @publisher[queue_name] ||= Sneakers::Publisher.new(queue_opts)
         end
       end
     end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -78,7 +78,12 @@ RSpec.describe ApplicationJob, type: :job do
     let(:error_exchange_name) { 'active_jobs-error' }
     let(:retry_queue_name) { retry_exchange_name }
     let(:error_queue_name) { error_exchange_name }
-    let(:child_class_queue) { channel.queue(prefixed_queue_name, durable: true) }
+    let(:child_class_queue) {
+      channel.queue(prefixed_queue_name,
+        durable: true,
+        arguments: {'x-dead-letter-exchange': "#{child_class.queue_name}-retry"}
+      )
+    }
     let(:child_class_name) { "#{Faker::Internet.slug(nil, '_')}_job".classify }
     let(:child_class) {
       klass_queue_name = child_class_queue_name

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -190,6 +190,16 @@ RSpec.describe ApplicationJob, type: :job do
         context 'when stopped' do
           before { job_wrapper_instance.stop }
           it { expect{child_class.perform_later}.to change{child_class_queue.message_count}.by(1) }
+          context 'creates a one Sneakers::Publisher' do
+            before { expect(Sneakers::Publisher).to receive(:new).and_call_original }
+            it 'when called once' do
+              expect{child_class.perform_later}.not_to raise_error
+            end
+            it 'when called twice' do
+              expect{child_class.perform_later}.not_to raise_error
+              expect{child_class.perform_later}.not_to raise_error
+            end
+          end
         end
       end
     end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe ApplicationJob, type: :job do
         context 'when stopped' do
           before { job_wrapper_instance.stop }
           it { expect{child_class.perform_later}.to change{child_class_queue.message_count}.by(1) }
-          context 'creates a one Sneakers::Publisher' do
+          context 'creates one Sneakers::Publisher' do
             before { expect(Sneakers::Publisher).to receive(:new).and_call_original }
             it 'when called once' do
               expect{child_class.perform_later}.not_to raise_error

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -131,6 +131,14 @@ RSpec.describe ApplicationJob, type: :job do
       it { expect(bunny_session.queue_exists?(prefixed_queue_name)).to be_falsey }
       it { expect{child_class.perform_later}.to raise_error(described_class::QueueNotFound, "Queue #{prefixed_queue_name} does not exist") }
 
+      context "when ENV[''] is set" do
+        include_context 'with env_override'
+        let(:env_override) { {
+          'SNEAKERS_SKIP_QUEUE_EXISTS_TEST' => 'yes'
+        } }
+        it { expect{child_class.perform_later}.not_to raise_error }
+      end
+
       context 'when not using sneakers' do
         before { expect{ActiveJob::Base.queue_adapter = :inline}.not_to raise_error }
         it { expect{child_class.perform_later}.not_to raise_error }


### PR DESCRIPTION
This addresses the RabbitMQ channel sprawl that resulted from new Sneakers::Publisher instances being created with each enqueued job. Publishers are now being cached on a per queue basis.