### PR TITLE
Rails ERD Changes. Builds model diagram

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN ["/root/installs/install_ssl_cert.sh"]
 #Postgresql client
 RUN /usr/bin/apt-get update && /usr/bin/apt-get install -y postgresql libpq-dev
 
+#GraphViz for Rails ERD
+RUN /usr/bin/apt-get install -y graphviz
+
 #miscellaneous
 RUN ["mkdir","-p","/var/www"]
 WORKDIR /var/www

--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ group :test do
   gem 'bunny-mock'
 end
 
-group :development do
+group :docker do
   gem "rails-erd"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,10 @@ group :test do
   gem 'bunny-mock'
 end
 
+group :development do
+  gem "rails-erd"
+end
+
 #heroku requires this
 group :docker, :development, :ua_test, :production do
   gem 'rails_12factor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
     bunny-mock (1.6.0)
       bunny (>= 1.7)
     byebug (9.0.6)
+    choice (0.2.0)
     coderay (1.1.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -247,6 +248,11 @@ GEM
     rails-dom-testing (2.0.2)
       activesupport (>= 4.2.0, < 6.0)
       nokogiri (~> 1.6)
+    rails-erd (1.5.2)
+      activerecord (>= 3.2)
+      activesupport (>= 3.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
     rails_12factor (0.0.3)
@@ -281,6 +287,7 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
+    ruby-graphviz (1.2.3)
     ruby-progressbar (1.8.1)
     rubyzip (1.2.1)
     safe_yaml (1.0.4)
@@ -368,6 +375,7 @@ DEPENDENCIES
   rack-timeout
   rails (~> 5.0)
   rails-controller-testing
+  rails-erd
   rails_12factor
   rspec-rails
   rspec_junit_formatter

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -37,6 +37,11 @@ services:
     volumes_from:
       - localdev
     entrypoint: ['bundle']
+  erd:
+    image: dukedataservice_server
+    volumes_from:
+      - localdev
+    entrypoint: ['erd']
     links:
       - db:postgres.db.host
       - neo4j:neo4j.db.host

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -37,6 +37,17 @@ services:
     volumes_from:
       - localdev
     entrypoint: ['bundle']
+    links:
+      - db:postgres.db.host
+      - neo4j:neo4j.db.host
+      - elasticsearch:elastic.local
+      - rabbitmq:rabbitmq.host
+    env_file:
+      - webapp.env
+      - swift.env
+      - neo4j.client.env
+      - elastic.client.env
+      - rabbitmq.client.env
   rake:
     image: dukedataservice_server
     volumes_from:


### PR DESCRIPTION
This is how you run to build the model diagrams: `docker-compose run bundle exec erd`

More information about Rails ERD available here:
http://voormedia.github.io/rails-erd/install.html