### PR TITLE
DDS-924 rule change update file permission

### DIFF
--- a/app/policies/data_file_policy.rb
+++ b/app/policies/data_file_policy.rb
@@ -20,7 +20,7 @@ class DataFilePolicy < ApplicationPolicy
   end
 
   def update?
-    system_permission || (project_permission(:update_file) && record.upload.creator == user)
+    permission :update_file
   end
 
   def destroy?

--- a/app/policies/data_file_policy.rb
+++ b/app/policies/data_file_policy.rb
@@ -12,7 +12,7 @@ class DataFilePolicy < ApplicationPolicy
   end
 
   def rename?
-    permission :create_file
+    permission :update_file
   end
 
   def create?

--- a/spec/policies/data_file_policy_spec.rb
+++ b/spec/policies/data_file_policy_spec.rb
@@ -14,25 +14,25 @@ describe DataFilePolicy do
   it_behaves_like 'system_permission can access', :data_file_without_upload
   it_behaves_like 'system_permission can access', :other_data_file
 
-  it_behaves_like 'a user with project_permission', :create_file, allows: [:create?, :move?, :rename?], denies: [:download?], on: :data_file
+  it_behaves_like 'a user with project_permission', :create_file, allows: [:create?, :move?], denies: [:download?, :rename?], on: :data_file
   it_behaves_like 'a user with project_permission', :view_project, allows: [:scope, :index?, :show?], denies: [:download?, :move?, :rename?], on: :data_file
-  it_behaves_like 'a user with project_permission', :update_file, allows: [:update?], denies: [:download?, :move?, :rename?], on: :data_file
+  it_behaves_like 'a user with project_permission', :update_file, allows: [:update?, :rename?], denies: [:download?, :move?], on: :data_file
   it_behaves_like 'a user with project_permission', :delete_file, allows: [:destroy?], denies: [:download?, :move?, :rename?], on: :data_file
   it_behaves_like 'a user with project_permission', :download_file, allows: [:download?], denies: [:move?, :rename?], on: :data_file
 
   context 'when user is not upload creator' do
     let(:upload) { FactoryGirl.create(:upload, :completed, :with_fingerprint, project: project_permission.project) }
 
-    it_behaves_like 'a user with project_permission', :create_file, allows: [:move?, :rename?], denies: [:download?], on: :data_file
+    it_behaves_like 'a user with project_permission', :create_file, allows: [:move?], denies: [:download?, :rename?], on: :data_file
     it_behaves_like 'a user with project_permission', :view_project, allows: [:scope, :index?, :show?], denies: [:download?, :move?, :rename?], on: :data_file
-    it_behaves_like 'a user with project_permission', :update_file, allows: [:update?], denies: [:download?, :move?, :rename?], on: :data_file
+    it_behaves_like 'a user with project_permission', :update_file, allows: [:update?, :rename?], denies: [:download?, :move?], on: :data_file
     it_behaves_like 'a user with project_permission', :delete_file, allows: [:destroy?], denies: [:download?, :move?, :rename?], on: :data_file
     it_behaves_like 'a user with project_permission', :download_file, allows: [:download?], denies: [:move?, :rename?], on: :data_file
   end
 
-  it_behaves_like 'a user with project_permission', :create_file, allows: [:move?, :rename?], denies: [:download?], on: :data_file_without_upload
+  it_behaves_like 'a user with project_permission', :create_file, allows: [:move?], denies: [:download?, :rename?], on: :data_file_without_upload
   it_behaves_like 'a user with project_permission', :view_project, allows: [:scope, :index?, :show?], denies: [:download?, :move?, :rename?], on: :data_file_without_upload
-  it_behaves_like 'a user with project_permission', :update_file, allows: [:update?], denies: [:download?, :move?, :rename?], on: :data_file_without_upload
+  it_behaves_like 'a user with project_permission', :update_file, allows: [:update?, :rename?], denies: [:download?, :move?], on: :data_file_without_upload
   it_behaves_like 'a user with project_permission', :delete_file, allows: [:destroy?], denies: [:download?, :move?, :rename?], on: :data_file_without_upload
   it_behaves_like 'a user with project_permission', :download_file, allows: [:download?], denies: [:move?, :rename?], on: :data_file_without_upload
 

--- a/spec/policies/data_file_policy_spec.rb
+++ b/spec/policies/data_file_policy_spec.rb
@@ -20,9 +20,19 @@ describe DataFilePolicy do
   it_behaves_like 'a user with project_permission', :delete_file, allows: [:destroy?], denies: [:download?, :move?, :rename?], on: :data_file
   it_behaves_like 'a user with project_permission', :download_file, allows: [:download?], denies: [:move?, :rename?], on: :data_file
 
+  context 'when user is not upload creator' do
+    let(:upload) { FactoryGirl.create(:upload, :completed, :with_fingerprint, project: project_permission.project) }
+
+    it_behaves_like 'a user with project_permission', :create_file, allows: [:move?, :rename?], denies: [:download?], on: :data_file
+    it_behaves_like 'a user with project_permission', :view_project, allows: [:scope, :index?, :show?], denies: [:download?, :move?, :rename?], on: :data_file
+    it_behaves_like 'a user with project_permission', :update_file, allows: [:update?], denies: [:download?, :move?, :rename?], on: :data_file
+    it_behaves_like 'a user with project_permission', :delete_file, allows: [:destroy?], denies: [:download?, :move?, :rename?], on: :data_file
+    it_behaves_like 'a user with project_permission', :download_file, allows: [:download?], denies: [:move?, :rename?], on: :data_file
+  end
+
   it_behaves_like 'a user with project_permission', :create_file, allows: [:move?, :rename?], denies: [:download?], on: :data_file_without_upload
   it_behaves_like 'a user with project_permission', :view_project, allows: [:scope, :index?, :show?], denies: [:download?, :move?, :rename?], on: :data_file_without_upload
-  it_behaves_like 'a user with project_permission', :update_file, allows: [], denies: [:download?, :move?, :rename?], on: :data_file_without_upload
+  it_behaves_like 'a user with project_permission', :update_file, allows: [:update?], denies: [:download?, :move?, :rename?], on: :data_file_without_upload
   it_behaves_like 'a user with project_permission', :delete_file, allows: [:destroy?], denies: [:download?, :move?, :rename?], on: :data_file_without_upload
   it_behaves_like 'a user with project_permission', :download_file, allows: [:download?], denies: [:move?, :rename?], on: :data_file_without_upload
 


### PR DESCRIPTION
- File updates no longer restricted to the upload creator
- File rename was using the incorrect permission. Changed from :create_file to :update_file, which is what is currently specified in the api docs.