### PR TITLE
tag elasticsearch index management

### DIFF
--- a/app/models/concerns/searchable_model.rb
+++ b/app/models/concerns/searchable_model.rb
@@ -7,6 +7,7 @@ module SearchableModel
 
     after_create :create_elasticsearch_index
     after_update :update_elasticsearch_index
+    after_touch :update_elasticsearch_index
 
     settings index: Rails.application.config.elasticsearch_index_settings
   end

--- a/app/models/meta_property.rb
+++ b/app/models/meta_property.rb
@@ -10,7 +10,6 @@ class MetaProperty < ActiveRecord::Base
 
   # callbacks
   before_validation :set_property_from_key
-  before_create :create_mapping
   after_save :update_templatable_document
   after_destroy :index_templatable_document
 
@@ -25,7 +24,7 @@ class MetaProperty < ActiveRecord::Base
       parsed_date = DateTime.parse(value)
     rescue
     end
-    record.errors.add(attr, message) unless parsed_date && 
+    record.errors.add(attr, message) unless parsed_date &&
       parsed_date.to_s(:iso8601).start_with?(value)
   end
 
@@ -40,59 +39,6 @@ class MetaProperty < ActiveRecord::Base
         self.property = meta_template.template.properties.where(key: key).first
       end
     end
-  end
-
-  def index_name
-    meta_template.templatable.class.index_name
-  end
-
-  def index_type
-    meta_template.templatable.class.name.underscore
-  end
-
-  def create_mapping
-    unless mapping_exists?
-      index_property = {
-        type: "#{property.data_type}"
-      }
-
-      if (property.data_type == "string")
-        index_property = {
-          type: "#{property.data_type}",
-          fields: {
-            raw: {
-              type: "#{property.data_type}",
-              index: "not_analyzed"
-            }
-          }
-        }
-      end
-
-      Elasticsearch::Model.client.indices.put_mapping index: index_name, type: index_type, body: {
-        index_type => {
-          properties: {
-            meta: {
-              properties: {
-                meta_template.template.name => {
-                  properties: {
-                    property.key => index_property
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    end
-  end
-
-  def mapping_exists?
-    current_mappings = Elasticsearch::Model.client.indices.get_mapping index: index_name
-    current_mappings[index_name].has_key?("mappings") &&
-      current_mappings[index_name]["mappings"].has_key?(index_type) &&
-      current_mappings[index_name]["mappings"][index_type]["properties"].has_key?("meta") &&
-      current_mappings[index_name]["mappings"][index_type]["properties"]["meta"]["properties"].has_key?(meta_template.template.name) &&
-      current_mappings[index_name]["mappings"][index_type]["properties"]["meta"]["properties"][meta_template.template.name]["properties"].has_key?(property.key)
   end
 
   def update_templatable_document
@@ -115,7 +61,7 @@ private
   end
 
   def numeric_data_types
-    [ 
+    [
       'long',
       'integer',
       'short',

--- a/app/models/meta_property.rb
+++ b/app/models/meta_property.rb
@@ -10,8 +10,6 @@ class MetaProperty < ActiveRecord::Base
 
   # callbacks
   before_validation :set_property_from_key
-  after_save :update_templatable_document
-  after_destroy :index_templatable_document
 
   validates :property, presence: true,
     uniqueness: {scope: [:meta_template_id], case_sensitive: false}
@@ -39,16 +37,6 @@ class MetaProperty < ActiveRecord::Base
         self.property = meta_template.template.properties.where(key: key).first
       end
     end
-  end
-
-  def update_templatable_document
-    reload
-    meta_template.templatable.__elasticsearch__.update_document
-  end
-
-  def index_templatable_document
-    meta_template.templatable.reload
-    meta_template.templatable.__elasticsearch__.index_document
   end
 
 private

--- a/app/models/meta_template.rb
+++ b/app/models/meta_template.rb
@@ -1,7 +1,7 @@
 class MetaTemplate < ActiveRecord::Base
   include RequestAudited
   audited
-  belongs_to :templatable, polymorphic: true
+  belongs_to :templatable, polymorphic: true, touch: true
   belongs_to :template
   has_many :meta_properties, autosave: true, dependent: :destroy
 

--- a/spec/lib/tasks/elasticsearch_rake_spec.rb
+++ b/spec/lib/tasks/elasticsearch_rake_spec.rb
@@ -18,39 +18,6 @@ describe "elasticsearch", :if => ENV['TEST_RAKE_SEARCH'] do
       current_indices = Elasticsearch::Model.client.cat.indices
       expect(current_indices).to include DataFile.index_name
     }
-
-    context 'with existing meta_properties' do
-      around :each do |example|
-        # initialize mappings
-        current_indices = DataFile.__elasticsearch__.client.cat.indices
-        if current_indices.include? DataFile.index_name
-          DataFile.__elasticsearch__.client.indices.delete index: DataFile.index_name
-        end
-        DataFile.__elasticsearch__.client.indices.create(
-          index: DataFile.index_name,
-          body: {
-            settings: DataFile.settings.to_hash,
-            mappings: DataFile.mappings.to_hash
-          }
-        )
-        Elasticsearch::Model.client.indices.flush
-
-        @meta_property = FactoryGirl.create(:meta_property)
-
-        DataFile.__elasticsearch__.client.indices.delete index: DataFile.index_name
-
-        example.run
-
-        DataFile.__elasticsearch__.client.indices.delete index: DataFile.index_name
-      end
-
-      it {
-        invoke_task
-        current_indices = Elasticsearch::Model.client.cat.indices
-        expect(current_indices).to include DataFile.index_name
-        expect(@meta_property.mapping_exists?).to be true
-      }
-    end
   end
 
   describe "elasticsearch:index:index_documents" do

--- a/spec/models/meta_template_spec.rb
+++ b/spec/models/meta_template_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe MetaTemplate, type: :model do
   it_behaves_like 'an audited model'
 
   describe 'associations' do
-    it { is_expected.to belong_to(:templatable) }
+    it { is_expected.to belong_to(:templatable).touch(true) }
     it { is_expected.to belong_to(:template) }
     it { is_expected.to have_many(:meta_properties).autosave(true).dependent(:destroy) }
   end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -57,4 +57,12 @@ RSpec.describe Tag, type: :model do
       it { expect(foo_tag_label.last_used_on).not_to eq(tags.first.created_at) }
     end
   end
+
+  describe 'taggable indexing' do
+    let(:resource) { FactoryGirl.build(:tag, taggable: file) }
+    before do
+      expect(file).to be_persisted
+    end
+    it_behaves_like 'a SearchableModel observer'
+  end
 end

--- a/spec/support/concerns/searchable_model_shared_examples.rb
+++ b/spec/support/concerns/searchable_model_shared_examples.rb
@@ -53,6 +53,7 @@ shared_examples 'a SearchableModel' do |resource_search_serializer_sym: :search_
     it { is_expected.to respond_to(:update_elasticsearch_index) }
     it {
       is_expected.to callback(:update_elasticsearch_index).after(:update)
+      is_expected.to callback(:update_elasticsearch_index).after(:touch)
     }
     it {
       expect(ElasticsearchIndexJob).to receive(:initialize_job).with(
@@ -69,4 +70,12 @@ shared_examples 'a SearchableModel' do |resource_search_serializer_sym: :search_
     it { is_expected.to respond_to('as_indexed_json').with(1).argument }
     it { expect(subject.as_indexed_json).to eq(resource_search_serializer.new(subject).as_json) }
   end
+end
+
+shared_examples 'a SearchableModel observer' do
+  it {
+    expect {
+      resource.save
+    }.to have_enqueued_job(ElasticsearchIndexJob).at_least(:once)
+  }
 end

--- a/spec/support/concerns/searchable_model_shared_examples.rb
+++ b/spec/support/concerns/searchable_model_shared_examples.rb
@@ -76,6 +76,6 @@ shared_examples 'a SearchableModel observer' do
   it {
     expect {
       resource.save
-    }.to have_enqueued_job(ElasticsearchIndexJob).at_least(:once)
+    }.to have_enqueued_job(ElasticsearchIndexJob)
   }
 end


### PR DESCRIPTION
tags should index/update their taggable elasticsearch indices the same way that meta_properties index/update their meta_template.templatable objects