### PR TITLE
DDS-997-998-is_deleted_index

### DIFF
--- a/api_design/DDS-826-reworking_search.md
+++ b/api_design/DDS-826-reworking_search.md
@@ -2,7 +2,7 @@
 
 ## Deployment View
 
-status: proposed
+status: in development
 
 ###### Deployment Requirements
 
@@ -314,6 +314,8 @@ Notice here that the raw non-analyzed index `tags.label.raw` is used to ensure a
 
 **aggs** & **post_filters** - project.name.raw, tags.label.raw
 
+is_deleted must be indexed for default search to filter out logically deleted objects. The interface will NOT provide the ability to use is_deleted in any queries.
+
 **Removed** many index definitions for fields from DataFile settings index
 which are not part of the new query, filter, agg interface.  Refer to
 [v1.3.8 DataFile](https://github.com/Duke-Translational-Bioinformatics/duke-data-service/blob/v1.3.8/app/models/data_file.rb) for these definitions if they need to be revived.
@@ -325,6 +327,8 @@ which are not part of the new query, filter, agg interface.  Refer to
 **filters** - kind.raw, project.id.raw
 
 **aggs** & **post_filters** - project.name.raw
+
+is_deleted must be indexed for default search to filter out logically deleted objects. The interface will NOT provide the ability to use is_deleted in any queries.
 
 **Removed** many index definitions for fields from Folder settings index
 which are not part of the new query, filter, agg interface.  Refer to
@@ -343,6 +347,7 @@ Serializers must serialize at least the following elements to elasticsearch.
     tags: {
       label: ...
     },
+    is_deleted: ...
     project: {
       name: ...,
       id: ...
@@ -363,6 +368,7 @@ to revive them if necessary.
   {
     name: ...,
     kind: ...,
+    is_deleted: ...
     project: {
       name: ...,
       id: ...

--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -81,6 +81,7 @@ class DataFile < Container
       }
 
       indexes :name
+      indexes :is_deleted, type: "boolean"
 
       indexes :tags do
         indexes :label, type: "string", fields: {

--- a/app/models/folder.rb
+++ b/app/models/folder.rb
@@ -37,6 +37,7 @@ class Folder < Container
       }
 
       indexes :name
+      indexes :is_deleted, type: "boolean"
 
       indexes :project do
         indexes :id, type: "string", fields: {

--- a/app/models/folder_files_response.rb
+++ b/app/models/folder_files_response.rb
@@ -65,7 +65,7 @@ class FolderFilesResponse
     validate_aggs
     validate_post_filters
 
-    query = build_query
+    query = hide_logically_deleted build_query
     search_definition(query)
     self
   end
@@ -248,5 +248,15 @@ class FolderFilesResponse
 
   def search_definition(query)
     @elastic_response = Elasticsearch::Model.search(query, @@all_indices)
+  end
+
+  private
+
+  def hide_logically_deleted(query)
+    # this may be turned into a context on the object in the future
+    query[:query][:filtered][:filter][:bool][:must_not] = {
+      term: {"is_deleted" => {"value": "true"}}
+    }
+    query
   end
 end

--- a/spec/models/data_file_spec.rb
+++ b/spec/models/data_file_spec.rb
@@ -320,6 +320,7 @@ RSpec.describe DataFile, type: :model do
     let(:property_mappings) {{
       kind: {type: "string"},
       name: {type: "string"}, #name
+      is_deleted: {type: "boolean"},
       tags: {type: "object"},
       project: {type: "object"}
     }}

--- a/spec/models/folder_files_response_spec.rb
+++ b/spec/models/folder_files_response_spec.rb
@@ -4,9 +4,15 @@ RSpec.describe FolderFilesResponse do
   let(:indexed_data_file) {
     FactoryGirl.create(:data_file, name: "foo bar")
   }
+  let(:deleted_data_file) {
+    FactoryGirl.create(:data_file, name: "foo bar", is_deleted: true)
+  }
   let(:tag) { FactoryGirl.create(:tag, taggable: indexed_data_file) }
   let(:indexed_folder) {
     FactoryGirl.create(:folder, name: "foo bar")
+  }
+  let(:deleted_folder) {
+    FactoryGirl.create(:folder, name: "foo bar", is_deleted: true)
   }
   let(:all_projects) {
     {'project.id' => [
@@ -169,13 +175,16 @@ RSpec.describe FolderFilesResponse do
             bool: {
               must: [
                 { terms: { "project.id.raw" => all_projects['project.id'] } }
-              ]
+              ],
+              must_not: {
+                term: { "is_deleted" => {:value => "true"} }
+              }
             }
           }
         }
       }
     }}
-    include_context 'elasticsearch prep', [:indexed_data_file, :indexed_folder], [:indexed_data_file, :indexed_folder]
+    include_context 'elasticsearch prep', [:indexed_data_file, :deleted_data_file, :indexed_folder, :deleted_folder], [:indexed_data_file, :deleted_data_file, :indexed_folder, :deleted_folder]
 
     before do
       subject.filter([all_projects])
@@ -188,6 +197,7 @@ RSpec.describe FolderFilesResponse do
         expect(response.results).not_to be_empty
         response.results.each do |result|
           expect(all_projects['project.id']).to include result[:project][:id]
+          expect(result[:is_deleted]).to eq false
         end
       end
     end
@@ -291,7 +301,10 @@ RSpec.describe FolderFilesResponse do
                         must: [
                           { terms: { "project.id.raw" => all_projects['project.id'] } },
                           { terms: { "kind.raw" => [supported_kind] }  }
-                        ]
+                        ],
+                        must_not: {
+                          term: { "is_deleted" => {:value => "true"} }
+                        }
                       }
                     }
                   }
@@ -328,7 +341,10 @@ RSpec.describe FolderFilesResponse do
                 bool: {
                   must: [
                     { terms: { "project.id.raw" => all_projects['project.id'] } }
-                  ]
+                  ],
+                  must_not: {
+                    term: { "is_deleted" => {:value => "true"} }
+                  }
                 }
               },
               query: {
@@ -340,7 +356,7 @@ RSpec.describe FolderFilesResponse do
             }
           }
         }}
-        include_context 'elasticsearch prep', [:indexed_data_file, :indexed_folder], [:indexed_data_file, :indexed_folder]
+        include_context 'elasticsearch prep', [:indexed_data_file, :deleted_data_file, :indexed_folder, :deleted_folder], [:indexed_data_file, :deleted_data_file, :indexed_folder, :deleted_folder]
 
         it {
           is_expected.to receive(:search_definition).with(expected_query)
@@ -359,7 +375,10 @@ RSpec.describe FolderFilesResponse do
                 bool: {
                   must: [
                     { terms: { "project.id.raw" => all_projects['project.id'] } }
-                  ]
+                  ],
+                  must_not: {
+                    term: { "is_deleted" => {:value => "true"} }
+                  }
                 }
               },
               query: {
@@ -371,7 +390,7 @@ RSpec.describe FolderFilesResponse do
             }
           }
         }}
-        include_context 'elasticsearch prep', [:indexed_data_file, :indexed_folder], [:indexed_data_file, :indexed_folder]
+        include_context 'elasticsearch prep', [:indexed_data_file, :deleted_data_file, :indexed_folder, :deleted_folder], [:indexed_data_file, :deleted_data_file, :indexed_folder, :deleted_folder]
 
         it {
           is_expected.to receive(:search_definition).with(expected_query)
@@ -396,13 +415,16 @@ RSpec.describe FolderFilesResponse do
                 bool: {
                   must: [
                     { terms: { "project.id.raw" => all_projects['project.id'] } }
-                  ]
+                  ],
+                  must_not: {
+                    term: { "is_deleted" => {:value => "true"} }
+                  }
                 }
               }
             }
           }
         }}
-        include_context 'elasticsearch prep', [:indexed_data_file, :indexed_folder], [:indexed_data_file, :indexed_folder]
+        include_context 'elasticsearch prep', [:indexed_data_file, :deleted_data_file, :indexed_folder, :deleted_folder], [:indexed_data_file, :deleted_data_file, :indexed_folder, :deleted_folder]
 
         it {
           is_expected.to receive(:search_definition).with(expected_query)
@@ -458,7 +480,10 @@ RSpec.describe FolderFilesResponse do
                     bool: {
                       must: [
                         { terms: { "project.id.raw" => all_projects['project.id'] } }
-                      ]
+                      ],
+                      must_not: {
+                        term: { "is_deleted" => {:value => "true"} }
+                      }
                     }
                   }
                 }
@@ -553,7 +578,10 @@ RSpec.describe FolderFilesResponse do
                     bool: {
                       must: [
                         { terms: { "project.id.raw" => all_projects['project.id'] } }
-                      ]
+                      ],
+                      must_not: {
+                        term: { "is_deleted" => {:value => "true"} }
+                      }
                     }
                   }
                 }
@@ -618,7 +646,10 @@ RSpec.describe FolderFilesResponse do
                 bool: {
                   must: [
                     { terms: { "project.id.raw" => all_projects['project.id'] } }
-                  ]
+                  ],
+                  must_not: {
+                    term: { "is_deleted" => {:value => "true"} }
+                  }
                 }
               }
             }
@@ -632,7 +663,7 @@ RSpec.describe FolderFilesResponse do
             }
           }
         }}
-        include_context 'elasticsearch prep', [:indexed_data_file, :indexed_folder], [:indexed_data_file, :indexed_folder]
+        include_context 'elasticsearch prep', [:indexed_data_file, :deleted_data_file, :indexed_folder, :deleted_folder], [:indexed_data_file, :deleted_data_file, :indexed_folder, :deleted_folder]
 
         before do
           subject.filter([all_projects])
@@ -664,7 +695,10 @@ RSpec.describe FolderFilesResponse do
                 bool: {
                   must: [
                     { terms: { "project.id.raw" => all_projects['project.id'] } }
-                  ]
+                  ],
+                  must_not: {
+                    term: { "is_deleted" => {:value => "true"} }
+                  }
                 }
               }
             }
@@ -678,7 +712,7 @@ RSpec.describe FolderFilesResponse do
             }
           }
         }}
-        include_context 'elasticsearch prep', [:indexed_data_file, :indexed_folder], [:indexed_data_file, :indexed_folder]
+        include_context 'elasticsearch prep', [:indexed_data_file, :deleted_data_file, :indexed_folder, :deleted_folder], [:indexed_data_file, :deleted_data_file, :indexed_folder, :deleted_folder]
 
         before do
           subject.filter([all_projects])
@@ -725,7 +759,10 @@ RSpec.describe FolderFilesResponse do
                 bool: {
                   must: [
                     { terms: { "project.id.raw" => all_projects['project.id'] } }
-                  ]
+                  ],
+                  must_not: {
+                    term: { "is_deleted" => {:value => "true"} }
+                  }
                 }
               }
             }
@@ -739,7 +776,7 @@ RSpec.describe FolderFilesResponse do
             }
           }
         }}
-        include_context 'elasticsearch prep', [:indexed_data_file, :indexed_folder], [:indexed_data_file, :indexed_folder]
+        include_context 'elasticsearch prep', [:indexed_data_file, :deleted_data_file, :indexed_folder, :deleted_folder], [:indexed_data_file, :deleted_data_file, :indexed_folder, :deleted_folder]
 
         before do
           subject.filter([all_projects])
@@ -896,7 +933,10 @@ RSpec.describe FolderFilesResponse do
                   bool: {
                     must: [
                       { terms: { "project.id.raw" => all_projects['project.id'] } }
-                    ]
+                    ],
+                    must_not: {
+                      term: { "is_deleted" => {:value => "true"} }
+                    }
                   }
                 }
               }
@@ -971,7 +1011,10 @@ RSpec.describe FolderFilesResponse do
                 must: [
                   { terms: { "project.id.raw" => all_projects['project.id'] } },
                   { terms: { "kind.raw" => [kind] }  }
-                ]
+                ],
+                must_not: {
+                  term: { "is_deleted" => {:value => "true"} }
+                }
               }
             },
             query: {
@@ -1006,8 +1049,7 @@ RSpec.describe FolderFilesResponse do
         }
       }
     }
-    include_context 'elasticsearch prep', [:indexed_data_file, :indexed_folder], [:indexed_data_file, :indexed_folder]
-
+    include_context 'elasticsearch prep', [:indexed_data_file, :deleted_data_file, :indexed_folder, :deleted_folder], [:indexed_data_file, :deleted_data_file, :indexed_folder, :deleted_folder]
     it {
       subject.query query_string
       subject.filter filters

--- a/spec/models/folder_spec.rb
+++ b/spec/models/folder_spec.rb
@@ -147,6 +147,7 @@ RSpec.describe Folder, type: :model do
     let(:property_mappings) {{
       kind: {type: "string"},
       name: {type: "string"}, #name
+      is_deleted: {type: "boolean"},
       project: {type: "object"}
     }}
     include_context 'with job runner', ElasticsearchIndexJob


### PR DESCRIPTION
- adds is_deleted to the mapped folder and file elasticsearch indices
- get /folder_files now only returns objects where is_deleted: false
- Added implementation notes to, and updated status in the design document