### PR TITLE
DDS-1025_elasticsearch_rake

### DIFF
--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -12,10 +12,6 @@ def create_indices
       }
     )
   end
-  # property mappings
-  MetaProperty.all.each do |mp|
-    mp.create_mapping
-  end
 end
 
 def index_documents

--- a/spec/lib/tasks/elasticsearch_rake_spec.rb
+++ b/spec/lib/tasks/elasticsearch_rake_spec.rb
@@ -55,8 +55,8 @@ describe "elasticsearch", :if => ENV['TEST_RAKE_SEARCH'] do
       it {
         invoke_task
         Elasticsearch::Model.client.indices.flush
-        expect(DataFile.__elasticsearch__.search(@data_file.id).count).to eq 1
-        expect(Folder.__elasticsearch__.search(@folder.id).count).to eq 1
+        expect(DataFile.__elasticsearch__.search(@data_file.name).count).to eq 1
+        expect(Folder.__elasticsearch__.search(@folder.name).count).to eq 1
       }
     end
 
@@ -95,11 +95,11 @@ describe "elasticsearch", :if => ENV['TEST_RAKE_SEARCH'] do
       end
 
       it {
-        expect(DataFile.__elasticsearch__.search(@data_file.id).count).to eq 1
-        expect(Folder.__elasticsearch__.search(@folder.id).count).to eq 1
+        expect(DataFile.__elasticsearch__.search(@data_file.name).count).to eq 1
+        expect(Folder.__elasticsearch__.search(@folder.name).count).to eq 1
         invoke_task
-        expect(DataFile.__elasticsearch__.search(@data_file.id).count).to eq 1
-        expect(Folder.__elasticsearch__.search(@folder.id).count).to eq 1
+        expect(DataFile.__elasticsearch__.search(@data_file.name).count).to eq 1
+        expect(Folder.__elasticsearch__.search(@folder.name).count).to eq 1
       }
     end
   end


### PR DESCRIPTION
creating MetaProperty mappings caused the index creation function to end in error, which
caused the rake task to end prematurely

test needed to search for file/folder by name instead of id, since we no longer index id