### PR TITLE
Chunk no longer updates Upload.etag on save

### DIFF
--- a/app/models/chunk.rb
+++ b/app/models/chunk.rb
@@ -2,7 +2,6 @@ class Chunk < ActiveRecord::Base
   include RequestAudited
   default_scope { order('created_at DESC') }
   audited
-  after_save :update_upload_etag
   after_destroy :update_upload_etag
 
   belongs_to :upload

--- a/spec/requests/uploads_api_spec.rb
+++ b/spec/requests/uploads_api_spec.rb
@@ -220,15 +220,9 @@ describe DDS::V1::UploadsAPI do
       end
 
       it_behaves_like 'an annotate_audits endpoint' do
-        let(:audit_should_include) { {user: current_user, audited_parent: 'Upload'} }
-      end
-      it_behaves_like 'an annotate_audits endpoint' do
         let(:resource_class) { Chunk }
       end
       it_behaves_like 'a software_agent accessible resource' do
-        it_behaves_like 'an annotate_audits endpoint' do
-          let(:audit_should_include) { {user: current_user, audited_parent: 'Upload', software_agent: software_agent} }
-        end
         it_behaves_like 'an annotate_audits endpoint' do
           let(:resource_class) { Chunk }
         end


### PR DESCRIPTION
This should fix the race conditions and db deadlock errors caused by multithreaded chunk creation.