### PR TITLE
neo4j changes

### DIFF
--- a/app/api/dds/v1/app_api.rb
+++ b/app/api/dds/v1/app_api.rb
@@ -45,7 +45,7 @@ module DDS
           end
 
           #graphdb must be configured
-          if ENV["GRAPHSTORY_URL"]
+          if ENV["GRAPHENEDB_URL"]
             #graphdb must be accessible with configured authentication or this will throw a Faraday::ConnectionFailed exception
             count = Neo4j::Session.query('MATCH (n) RETURN COUNT(n)').first["COUNT(n)"]
           else

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
     LOCALDEV: true
     DDSURL: http://0.0.0.0:3001
     COMPOSE_FILE: 'docker-compose.circle.yml:docker-compose.swift.yml'
-    GRAPHSTORY_URL: http://neo4j.db.host:7474
+    GRAPHENEDB_URL: http://neo4j.db.host:7474
     BONSAI_URL: elastic.local:9200
     OPENID_CLIENT_ID: test
     OPENID_CLIENT_SECRET: testpass
@@ -27,10 +27,10 @@ dependencies:
   cache_directories:
     - "docker/circle"
   pre:
-    - ./docker/circle/cache_docker_image.sh neo4j 3.0.2
+    - ./docker/circle/cache_docker_image.sh neo4j 3.1.6
     - ./docker/circle/cache_docker_image.sh elasticsearch 2.4
 #    - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 > jq; sudo mv jq /usr/bin/jq; sudo chmod +x /usr/bin/jq
-    - sudo pip install --upgrade docker-compose==1.8.0
+    - sudo pip install --upgrade docker-compose==1.16.1
     - docker-compose up -d neo4j elasticsearch
 
 deployment:

--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ dependencies:
     - ./docker/circle/cache_docker_image.sh neo4j 3.1.6
     - ./docker/circle/cache_docker_image.sh elasticsearch 2.4
 #    - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 > jq; sudo mv jq /usr/bin/jq; sudo chmod +x /usr/bin/jq
-    - sudo pip install --upgrade docker-compose==1.16.1
+    - sudo pip install --upgrade docker-compose==1.8.0
     - docker-compose up -d neo4j elasticsearch
 
 deployment:

--- a/config/application.rb
+++ b/config/application.rb
@@ -55,8 +55,9 @@ module DukeDataService
       end
     end
     # Neo4j using Graph Story
+    config.neo4j.wait_for_connection = true
     config.neo4j.session_type = :server_db
-    config.neo4j.session_path = ENV["GRAPHSTORY_URL"]
+    config.neo4j.session_path = ENV["GRAPHENEDB_URL"]
 
     # ActiveJob using Sneakers(RabbitMQ)
     config.active_job.queue_adapter = ENV['ACTIVE_JOB_QUEUE_ADAPTER'] || :sneakers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     env_file:
       - db.env
   neo4j:
-    image: neo4j:3.0.2
+    image: neo4j:3.1.6
     ports:
       - '7474:7474'
     env_file:

--- a/neo4j.client.local.env
+++ b/neo4j.client.local.env
@@ -1,1 +1,1 @@
-GRAPHSTORY_URL=http://neo4j.db.host:7474
+GRAPHENEDB_URL=http://neo4j.db.host:7474

--- a/spec/requests/app_api_spec.rb
+++ b/spec/requests/app_api_spec.rb
@@ -19,7 +19,7 @@ describe DDS::V1::AppAPI do
     end
   end
   before do
-    ENV["GRAPHSTORY_URL"] = 'http://neo4j.db.host:7474'
+    ENV["GRAPHENEDB_URL"] = 'http://neo4j.db.host:7474'
   end
 
   describe 'app status', :vcr do
@@ -125,7 +125,7 @@ describe DDS::V1::AppAPI do
       context 'environment is not set' do
         let(:status_error) { 'graphdb environment is not set' }
         before do
-          ENV["GRAPHSTORY_URL"] = nil
+          ENV["GRAPHENEDB_URL"] = nil
         end
         it_behaves_like 'a status error', :status_error
       end


### PR DESCRIPTION
- updated neo4j in docker-compose and circle.yml to 3.1.6 to match graphenedb provisioned instance
- added config.neo4j.wait_for_connection = true to application.rb to ensure that the application
  waits for up to 60 seconds before crashing while neo4j starts
- replaced GRAPHSTORY_URL with GRAPHENEDB_URL in places where it is set or used