### PR TITLE
DDS-1023 elasticsearch 5.x upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,9 +27,9 @@ gem 'grape-kaminari'
 
 # Use elasticsearch for search
 # must be included after kaminari according to elasticsearch-model documentation
-gem 'elasticsearch', '~> 2.0.0'
-gem 'elasticsearch-model', '~> 2.0.0'
-gem 'elasticsearch-rails', '~> 2.0.0'
+gem 'elasticsearch', '~> 5.0'
+gem 'elasticsearch-model', '~> 5.0'
+gem 'elasticsearch-rails', '~> 5.0'
 
 
 # Auditing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,17 +70,17 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
-    elasticsearch (2.0.2)
-      elasticsearch-api (= 2.0.2)
-      elasticsearch-transport (= 2.0.2)
-    elasticsearch-api (2.0.2)
+    elasticsearch (5.0.4)
+      elasticsearch-api (= 5.0.4)
+      elasticsearch-transport (= 5.0.4)
+    elasticsearch-api (5.0.4)
       multi_json
-    elasticsearch-model (2.0.1)
+    elasticsearch-model (5.0.2)
       activesupport (> 3)
-      elasticsearch (~> 2)
+      elasticsearch (~> 5)
       hashie
-    elasticsearch-rails (2.0.1)
-    elasticsearch-transport (2.0.2)
+    elasticsearch-rails (5.0.2)
+    elasticsearch-transport (5.0.4)
       faraday
       multi_json
     enumerable-lazy (0.0.2)
@@ -340,9 +340,9 @@ DEPENDENCIES
   active_record_union
   audited
   bunny-mock
-  elasticsearch (~> 2.0.0)
-  elasticsearch-model (~> 2.0.0)
-  elasticsearch-rails (~> 2.0.0)
+  elasticsearch (~> 5.0)
+  elasticsearch-model (~> 5.0)
+  elasticsearch-rails (~> 5.0)
   factory_girl_rails
   faker
   grape (= 0.16.2)

--- a/app/jobs/elasticsearch_index_job.rb
+++ b/app/jobs/elasticsearch_index_job.rb
@@ -4,7 +4,8 @@ class ElasticsearchIndexJob < ApplicationJob
   def perform(job_transaction, container, update: false)
     self.class.start_job job_transaction
     if update
-      unless container.__elasticsearch__.update_document(ignore: 404)
+      resp = container.__elasticsearch__.update_document(ignore: 404)
+      unless resp && resp["result"] == "updated"
         container.__elasticsearch__.index_document
       end
     else

--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -80,7 +80,7 @@ class DataFile < Container
         raw: {type: "string", index: "not_analyzed"}
       }
 
-      indexes :name
+      indexes :name, type: "string"
       indexes :is_deleted, type: "boolean"
 
       indexes :tags do

--- a/app/models/folder.rb
+++ b/app/models/folder.rb
@@ -36,7 +36,7 @@ class Folder < Container
         raw: {type: "string", index: "not_analyzed"}
       }
 
-      indexes :name
+      indexes :name, type: "string"
       indexes :is_deleted, type: "boolean"
 
       indexes :project do

--- a/app/models/folder_files_response.rb
+++ b/app/models/folder_files_response.rb
@@ -182,7 +182,7 @@ class FolderFilesResponse
 
     query = {
       query: {
-        filtered: {
+        bool: {
           filter: {
             bool: {
               must: filter_terms
@@ -194,13 +194,13 @@ class FolderFilesResponse
 
     if @query_string
       if @query_string[:query].match(/\s/)
-        query[:query][:filtered][:query] = {
+        query[:query][:bool][:must] = {
           query_string: {
             query: "*#{@query_string[:query]}* *#{@query_string[:query].gsub(/\s/,'* *')}*"
           }
         }
       else
-        query[:query][:filtered][:query] = {
+        query[:query][:bool][:must] = {
           query_string: {
             query: "*#{@query_string[:query]}*"
           }
@@ -208,9 +208,9 @@ class FolderFilesResponse
       end
 
       if @query_string[:fields]
-        query[:query][:filtered][:query][:query_string][:fields] = @query_string[:fields]
+        query[:query][:bool][:must][:query_string][:fields] = @query_string[:fields]
       else
-        query[:query][:filtered][:query][:query_string][:fields] = @@supported_query_string_fields
+        query[:query][:bool][:must][:query_string][:fields] = @@supported_query_string_fields
       end
     end
 
@@ -254,7 +254,7 @@ class FolderFilesResponse
 
   def hide_logically_deleted(query)
     # this may be turned into a context on the object in the future
-    query[:query][:filtered][:filter][:bool][:must_not] = {
+    query[:query][:bool][:filter][:bool][:must_not] = {
       term: {"is_deleted" => {"value": "true"}}
     }
     query

--- a/circle.yml
+++ b/circle.yml
@@ -28,7 +28,7 @@ dependencies:
     - "docker/circle"
   pre:
     - ./docker/circle/cache_docker_image.sh neo4j 3.1.6
-    - ./docker/circle/cache_docker_image.sh elasticsearch 2.4
+    - ./docker/circle/cache_docker_image.sh elasticsearch 5.4.3
 #    - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 > jq; sudo mv jq /usr/bin/jq; sudo chmod +x /usr/bin/jq
     - sudo pip install --upgrade docker-compose==1.8.0
     - docker-compose up -d neo4j elasticsearch

--- a/docker-compose.circle.yml
+++ b/docker-compose.circle.yml
@@ -28,7 +28,9 @@ services:
     image: elasticsearch:5.4.3
     ports:
       - '9200:9200'
-    command: elasticsearch --action.auto_create_index=0
+    environment:
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    command: elasticsearch -E 'action.auto_create_index=false'
   worker:
     image: dukedataservice_server
     entrypoint: ['rake', 'workers:run']

--- a/docker-compose.circle.yml
+++ b/docker-compose.circle.yml
@@ -25,7 +25,7 @@ services:
     env_file:
       - neo4j.server.env
   elasticsearch:
-    image: elasticsearch:2.4
+    image: elasticsearch:5.4.3
     ports:
       - '9200:9200'
     command: elasticsearch --action.auto_create_index=0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     env_file:
       - neo4j.server.env
   elasticsearch:
-    image: elasticsearch:2.4
+    image: elasticsearch:5.4.3
     ports:
       - '9200:9200'
     command: elasticsearch --action.auto_create_index=0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,9 @@ services:
     image: elasticsearch:5.4.3
     ports:
       - '9200:9200'
-    command: elasticsearch --action.auto_create_index=0
+    environment:
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    command: elasticsearch -E 'action.auto_create_index=false'
   rabbitmq:
     hostname: rabbitmq.host
     container_name: rabbitmq

--- a/spec/models/folder_files_response_spec.rb
+++ b/spec/models/folder_files_response_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe FolderFilesResponse do
 
     let(:expected_query) {{
       query: {
-        filtered: {
+        bool: {
           filter: {
             bool: {
               must: [
@@ -295,7 +295,7 @@ RSpec.describe FolderFilesResponse do
             expect {
               expected_query = {
                 query: {
-                  filtered: {
+                  bool: {
                     filter: {
                       bool: {
                         must: [
@@ -336,7 +336,7 @@ RSpec.describe FolderFilesResponse do
         let(:query) { indexed_folder.name.split(' ')[0] }
         let(:expected_query) {{
           query: {
-            filtered: {
+            bool: {
               filter: {
                 bool: {
                   must: [
@@ -347,7 +347,7 @@ RSpec.describe FolderFilesResponse do
                   }
                 }
               },
-              query: {
+              must: {
                 query_string: {
                   fields: described_class.supported_query_string_fields,
                   query: "*#{query}*"
@@ -370,7 +370,7 @@ RSpec.describe FolderFilesResponse do
         let(:query) { indexed_folder.name }
         let(:expected_query) {{
           query: {
-            filtered: {
+            bool: {
               filter: {
                 bool: {
                   must: [
@@ -381,7 +381,7 @@ RSpec.describe FolderFilesResponse do
                   }
                 }
               },
-              query: {
+              must: {
                 query_string: {
                   query: "*#{query}* *#{query.gsub(/\s/,'* *')}*",
                   fields: described_class.supported_query_string_fields
@@ -404,8 +404,8 @@ RSpec.describe FolderFilesResponse do
         let(:query) { indexed_folder.name[0,2] }
         let(:expected_query) {{
           query: {
-            filtered: {
-              query: {
+            bool: {
+              must: {
                 query_string: {
                   query: "*#{query}*",
                   fields: described_class.supported_query_string_fields
@@ -469,8 +469,8 @@ RSpec.describe FolderFilesResponse do
           described_class.supported_query_string_fields.each do |supported_field|
             expected_query = {
               query: {
-                filtered: {
-                  query: {
+                bool: {
+                  must: {
                     query_string: {
                       fields: [supported_field],
                       query: "*#{query_lookup[supported_field]}*"
@@ -573,7 +573,7 @@ RSpec.describe FolderFilesResponse do
             field_name = Faker::Beer.hop
             expected_query = {
               query: {
-                filtered: {
+                bool: {
                   filter: {
                     bool: {
                       must: [
@@ -641,7 +641,7 @@ RSpec.describe FolderFilesResponse do
         }
         let(:expected_query) {{
           query: {
-            filtered: {
+            bool: {
               filter: {
                 bool: {
                   must: [
@@ -690,7 +690,7 @@ RSpec.describe FolderFilesResponse do
         }
         let(:expected_query) {{
           query: {
-            filtered: {
+            bool: {
               filter: {
                 bool: {
                   must: [
@@ -754,7 +754,7 @@ RSpec.describe FolderFilesResponse do
         }
         let(:expected_query) {{
           query: {
-            filtered: {
+            bool: {
               filter: {
                 bool: {
                   must: [
@@ -928,7 +928,7 @@ RSpec.describe FolderFilesResponse do
           size = field_value_lookup[supported_post_filter_field][:size]
           expected_query = {
             query: {
-              filtered: {
+              bool: {
                 filter: {
                   bool: {
                     must: [
@@ -1005,7 +1005,7 @@ RSpec.describe FolderFilesResponse do
     let(:expected_query) {
       {
         query: {
-          filtered: {
+          bool: {
             filter: {
               bool: {
                 must: [
@@ -1017,7 +1017,7 @@ RSpec.describe FolderFilesResponse do
                 }
               }
             },
-            query: {
+            must: {
               query_string: {
                 query: "*#{query}*",
                 fields: [query_field]


### PR DESCRIPTION
- Upgrading elasticsearch gems to 5.x version
- Using elasticsearch:5.4.3 docker image
- Fixed any breaking changes introduced by elasticsearch 5.x: https://www.elastic.co/guide/en/elasticsearch/reference/5.0/breaking-changes.html