### PR TITLE
DDS-1090-trashbin_children_sorting

### DIFF
--- a/app/api/dds/v1/trashbin_api.rb
+++ b/app/api/dds/v1/trashbin_api.rb
@@ -183,7 +183,7 @@ module DDS
         authorize DataFile.new(project: project), :index?
         name_contains = params[:name_contains]
         descendants = params[:recurse] ? project.containers : project.children
-        descendants = descendants.where(is_deleted: true, is_purged: false)
+        descendants = descendants.unscope(:order).where(is_deleted: true, is_purged: false)
         if name_contains
           if name_contains.empty?
             descendants = descendants.none

--- a/app/api/dds/v1/trashbin_api.rb
+++ b/app/api/dds/v1/trashbin_api.rb
@@ -160,7 +160,7 @@ module DDS
             descendants = descendants.where(Container.arel_table[:name].matches("%#{name_contains}%"))
           end
         end
-        paginate(descendants.includes(:parent, :project, :audits))
+        paginate(descendants.includes(:parent, :project, :audits).order('updated_at ASC'))
       end
 
       desc 'List project children in the trashbin' do
@@ -191,7 +191,7 @@ module DDS
             descendants = descendants.where(Container.arel_table[:name].matches("%#{name_contains}%"))
           end
         end
-        paginate(policy_scope(descendants.includes(:parent, :project, :audits)))
+        paginate(policy_scope(descendants.includes(:parent, :project, :audits).order('updated_at ASC')))
       end
     end
   end

--- a/app/api/dds/v1/trashbin_api.rb
+++ b/app/api/dds/v1/trashbin_api.rb
@@ -152,7 +152,7 @@ module DDS
         authorize folder, :index?
         name_contains = params[:name_contains]
         descendants = params[:recurse] ? policy_scope(folder.descendants) : policy_scope(folder.children)
-        descendants = descendants.where(is_deleted: true, is_purged: false)
+        descendants = descendants.unscope(:order).where(is_deleted: true, is_purged: false)
         if name_contains
           if name_contains.empty?
             descendants = descendants.none

--- a/spec/requests/trashbin_api_spec.rb
+++ b/spec/requests/trashbin_api_spec.rb
@@ -335,6 +335,14 @@ describe DDS::V1::TrashbinAPI do
           end
         end
 
+        it_behaves_like 'a sorted index resource', :trashed_resource do
+          let(:sort_column) { :updated_at }
+          let(:sort_order) { "asc" }
+          before do
+            trashed_resource.touch
+          end
+        end
+
         it_behaves_like 'an authenticated resource'
         it_behaves_like 'a software_agent accessible resource'
 
@@ -434,6 +442,13 @@ describe DDS::V1::TrashbinAPI do
               trashed_resource_in_trashed_folder
             ] }
           end
+          it_behaves_like 'a sorted index resource', :named_trashed_resource do
+            let(:sort_column) { :updated_at }
+            let(:sort_order) { "asc" }
+            before do
+              named_trashed_resource.touch
+            end
+          end
         end
       end
 
@@ -462,6 +477,14 @@ describe DDS::V1::TrashbinAPI do
               named_trashed_resource_in_trashed_folder,
               trashed_resource_in_trashed_folder
             ] }
+          end
+
+          it_behaves_like 'a sorted index resource', :named_trashed_resource do
+            let(:sort_column) { :updated_at }
+            let(:sort_order) { "asc" }
+            before do
+              named_trashed_resource.touch
+            end
           end
         end
       end
@@ -493,6 +516,14 @@ describe DDS::V1::TrashbinAPI do
             named_purged_resource
           ] }
         end
+
+        it_behaves_like 'a sorted index resource', :named_trashed_resource do
+          let(:sort_column) { :updated_at }
+          let(:sort_order) { "asc" }
+          before do
+            named_trashed_resource.touch
+          end
+        end
       end
     end
 
@@ -521,6 +552,14 @@ describe DDS::V1::TrashbinAPI do
             purged_resource,
             named_purged_resource
           ] }
+        end
+
+        it_behaves_like 'a sorted index resource', :named_trashed_resource do
+          let(:sort_column) { :updated_at }
+          let(:sort_order) { "asc" }
+          before do
+            named_trashed_resource.touch
+          end
         end
       end
     end
@@ -563,6 +602,14 @@ describe DDS::V1::TrashbinAPI do
             let(:expected_total_length) { parent_folder.children.count }
             let(:extras) { FactoryBot.create_list(:folder, 5, :deleted, parent: parent_folder, project: project) }
           end
+
+          it_behaves_like 'a sorted index resource', :named_trashed_child_folder do
+            let(:sort_column) { :updated_at }
+            let(:sort_order) { "asc" }
+            before do
+              named_trashed_child_folder.touch
+            end
+          end
         end
       end
 
@@ -588,6 +635,13 @@ describe DDS::V1::TrashbinAPI do
               purged_resource,
               named_purged_resource,
             ] }
+          end
+          it_behaves_like 'a sorted index resource', :named_trashed_resource_in_trashed_folder do
+            let(:sort_column) { :updated_at }
+            let(:sort_order) { "asc" }
+            before do
+              named_trashed_resource_in_trashed_folder.touch
+            end
           end
         end
       end
@@ -620,6 +674,13 @@ describe DDS::V1::TrashbinAPI do
             trashed_resource_in_trashed_folder
           ] }
         end
+        it_behaves_like 'a sorted index resource', :named_trashed_child_folder do
+          let(:sort_column) { :updated_at }
+          let(:sort_order) { "asc" }
+          before do
+            named_trashed_child_folder.touch
+          end
+        end
       end
     end
 
@@ -650,6 +711,13 @@ describe DDS::V1::TrashbinAPI do
             trashed_resource_in_trashed_folder
           ] }
         end
+        it_behaves_like 'a sorted index resource', :named_trashed_child_folder do
+          let(:sort_column) { :updated_at }
+          let(:sort_order) { "asc" }
+          before do
+            named_trashed_child_folder.touch
+          end
+        end
       end
     end
 
@@ -679,6 +747,13 @@ describe DDS::V1::TrashbinAPI do
             named_trashed_resource_in_trashed_folder,
             trashed_resource_in_trashed_folder
           ] }
+        end
+        it_behaves_like 'a sorted index resource', :named_trashed_child_folder do
+          let(:sort_column) { :updated_at }
+          let(:sort_order) { "asc" }
+          before do
+            named_trashed_child_folder.touch
+          end
         end
       end
     end

--- a/spec/requests/trashbin_api_spec.rb
+++ b/spec/requests/trashbin_api_spec.rb
@@ -588,21 +588,20 @@ describe DDS::V1::TrashbinAPI do
   end
 
   describe 'GET /trashbin/folders/{id}/children{?name_contains}{?recurse}' do
-    let(:url) { "/api/v1/trashbin/folders/#{parent_id}/children#{query_params}" }
+    let(:url) { "/api/v1/trashbin/folders/#{parent_id}/children" }
     let(:payload) {{}}
 
     context 'default' do
-      let(:query_params) { '' }
 
       context 'untrashed folder' do
         let(:parent_id) { parent_folder.id }
+        let(:expected_resources) {[
+          named_trashed_child_folder,
+          trashed_child_resource
+        ]}
 
         it_behaves_like 'a GET request' do
           it_behaves_like 'a searchable resource' do
-            let(:expected_resources) {[
-              named_trashed_child_folder,
-              trashed_child_resource
-            ]}
             let(:unexpected_resources) { [
               parent_folder,
               depth_trashed_resource,
@@ -629,6 +628,9 @@ describe DDS::V1::TrashbinAPI do
             let(:sort_column) { :updated_at }
             let(:sort_order) { "asc" }
             before do
+              expected_resources.each do |expected_resource|
+                expect(expected_resource).to be_persisted
+              end
               named_trashed_child_folder.touch
             end
           end
@@ -637,13 +639,13 @@ describe DDS::V1::TrashbinAPI do
 
       context 'trashed folder' do
         let(:parent_id) { named_trashed_folder.id }
+        let(:expected_resources) {[
+          named_trashed_resource_in_trashed_folder,
+          trashed_resource_in_trashed_folder
+        ]}
 
         it_behaves_like 'a GET request' do
           it_behaves_like 'a searchable resource' do
-            let(:expected_resources) {[
-              named_trashed_resource_in_trashed_folder,
-              trashed_resource_in_trashed_folder
-            ]}
             let(:unexpected_resources) { [
               parent_folder,
               named_trashed_child_folder,
@@ -662,6 +664,9 @@ describe DDS::V1::TrashbinAPI do
             let(:sort_column) { :updated_at }
             let(:sort_order) { "asc" }
             before do
+              expected_resources.each do |expected_resource|
+                expect(expected_resource).to be_persisted
+              end
               named_trashed_resource_in_trashed_folder.touch
             end
           end
@@ -671,7 +676,9 @@ describe DDS::V1::TrashbinAPI do
 
     context 'name_contains' do
       let(:parent_id) { parent_folder.id }
-      let(:query_params) { '?name_contains=XXXX' }
+      let(:payload) {{
+        name_contains: 'XXXX'
+      }}
 
       it_behaves_like 'a GET request' do
         it_behaves_like 'a searchable resource' do
@@ -696,28 +703,23 @@ describe DDS::V1::TrashbinAPI do
             trashed_resource_in_trashed_folder
           ] }
         end
-        it_behaves_like 'a sorted index resource', :named_trashed_child_folder do
-          let(:sort_column) { :updated_at }
-          let(:sort_order) { "asc" }
-          before do
-            named_trashed_child_folder.touch
-          end
-        end
       end
     end
 
     context 'recurse' do
       let(:parent_id) { parent_folder.id }
-      let(:query_params) { '?recurse=true' }
+      let(:payload) {{
+        recurse: true
+      }}
+      let(:expected_resources) { [
+        named_trashed_child_folder,
+        trashed_child_resource,
+        depth_trashed_resource,
+        depth_named_trashed_resource
+      ] }
 
       it_behaves_like 'a GET request' do
         it_behaves_like 'a searchable resource' do
-          let(:expected_resources) { [
-            named_trashed_child_folder,
-            trashed_child_resource,
-            depth_trashed_resource,
-            depth_named_trashed_resource
-          ] }
           let(:unexpected_resources) { [
             parent_folder,
             depth_purged_resource,
@@ -737,6 +739,9 @@ describe DDS::V1::TrashbinAPI do
           let(:sort_column) { :updated_at }
           let(:sort_order) { "asc" }
           before do
+            expected_resources.each do |expected_resource|
+              expect(expected_resource).to be_persisted
+            end
             named_trashed_child_folder.touch
           end
         end
@@ -745,14 +750,17 @@ describe DDS::V1::TrashbinAPI do
 
     context 'name_contains and resurse' do
       let(:parent_id) { parent_folder.id }
-      let(:query_params) { '?name_contains=XXXX&recurse=true' }
+      let(:payload) {{
+        name_contains:'XXXX',
+        recurse: true
+      }}
+      let(:expected_resources) { [
+        named_trashed_child_folder,
+        depth_named_trashed_resource
+      ] }
 
       it_behaves_like 'a GET request' do
         it_behaves_like 'a searchable resource' do
-          let(:expected_resources) { [
-            named_trashed_child_folder,
-            depth_named_trashed_resource
-          ] }
           let(:unexpected_resources) { [
             parent_folder,
             trashed_child_resource,
@@ -774,6 +782,9 @@ describe DDS::V1::TrashbinAPI do
           let(:sort_column) { :updated_at }
           let(:sort_order) { "asc" }
           before do
+            expected_resources.each do |expected_resource|
+              expect(expected_resource).to be_persisted
+            end
             named_trashed_child_folder.touch
           end
         end

--- a/spec/support/requests_shared_examples.rb
+++ b/spec/support/requests_shared_examples.rb
@@ -224,17 +224,26 @@ shared_examples 'a sorted index resource' do |expected_last_item_sym|
     expect(response_json).to have_key('results')
     returned_results = response_json['results']
     expect(returned_results).to be_a(Array)
+    expect(returned_results).not_to be_empty
     last_date = nil
     returned_results.each do |this_result|
       this_result_object = KindnessFactory.by_kind(this_result["kind"]).find(this_result["id"])
-      if last_date.nil?
-        last_date = this_result_object.send(sort_column)
-      elsif sort_order == "asc"
+      last_date = this_result_object.send(sort_column) if last_date.nil?
+
+      if sort_order == "asc"
         expect(this_result_object.send(sort_column)).to be >= last_date
       else
         expect(this_result_object.send(sort_column)).to be <= last_date
       end
+      last_date = this_result_object.send(sort_column)
     end
+  end
+
+  it 'should end with the expected last item' do
+    is_expected.to eq(expected_response_status)
+    response_json = JSON.parse(response.body)
+    expect(response_json).to have_key('results')
+    returned_results = response_json['results']
     expect(returned_results.last["id"]).to eq(expected_last_item.id)
   end
 end

--- a/spec/support/requests_shared_examples.rb
+++ b/spec/support/requests_shared_examples.rb
@@ -225,6 +225,7 @@ shared_examples 'a sorted index resource' do |expected_last_item_sym|
     returned_results = response_json['results']
     expect(returned_results).to be_a(Array)
     expect(returned_results).not_to be_empty
+    expect(returned_results.count).to be > 1
     last_date = nil
     returned_results.each do |this_result|
       this_result_object = KindnessFactory.by_kind(this_result["kind"]).find(this_result["id"])


### PR DESCRIPTION
ensures results from trashbin/{folder|project}/{id}/chidren are sorted by updated_at ascending