### PR TITLE
DDS-1098-container_deletion_parent

### DIFF
--- a/app/api/dds/v1/files_api.rb
+++ b/app/api/dds/v1/files_api.rb
@@ -145,7 +145,9 @@ module DDS
         authenticate!
         file = hide_logically_deleted(DataFile.find(params[:id]))
         authorize file, :destroy?
-        file.update_attribute(:is_deleted, true)
+        file.is_deleted = true
+        file.set_deleted_from_parent
+        file.save
         body false
       end
 

--- a/app/api/dds/v1/files_api.rb
+++ b/app/api/dds/v1/files_api.rb
@@ -145,8 +145,7 @@ module DDS
         authenticate!
         file = hide_logically_deleted(DataFile.find(params[:id]))
         authorize file, :destroy?
-        file.is_deleted = true
-        file.set_deleted_from_parent
+        file.move_to_trashbin
         file.save
         body false
       end

--- a/app/api/dds/v1/folders_api.rb
+++ b/app/api/dds/v1/folders_api.rb
@@ -69,7 +69,9 @@ module DDS
         authenticate!
         folder = hide_logically_deleted Folder.find(params[:id])
         authorize folder, :destroy?
-        folder.update(is_deleted: true)
+        folder.is_deleted = true
+        folder.set_deleted_from_parent
+        folder.save
         body false
       end
 

--- a/app/api/dds/v1/folders_api.rb
+++ b/app/api/dds/v1/folders_api.rb
@@ -69,8 +69,7 @@ module DDS
         authenticate!
         folder = hide_logically_deleted Folder.find(params[:id])
         authorize folder, :destroy?
-        folder.is_deleted = true
-        folder.set_deleted_from_parent
+        folder.move_to_trashbin
         folder.save
         body false
       end

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -8,10 +8,12 @@ class Container < ActiveRecord::Base
   audited
   belongs_to :project
 	belongs_to :parent, class_name: "Folder"
+  belongs_to :deleted_from_parent, class_name: "Folder"
   has_many :project_permissions, through: :project
   has_many :tags, as: :taggable
 
   define_model_callbacks :set_parent_attribute
+
   validates :name, presence: true, unless: :is_deleted
 
   def ancestors
@@ -36,5 +38,15 @@ class Container < ActiveRecord::Base
 
   def set_project_to_parent_project
     self.project = self.parent.project if self.parent
+  end
+
+  def set_deleted_from_parent
+    if is_deleted?
+      self.deleted_from_parent_id = self.parent_id
+      self.parent_id = nil
+    elsif is_deleted_was && !is_deleted?
+      self.parent_id = self.deleted_from_parent_id
+      self.deleted_from_parent_id = nil
+    end
   end
 end

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -54,8 +54,12 @@ class Container < ActiveRecord::Base
     elsif new_parent.is_a? Folder
       self.deleted_from_parent_id = nil
       self.parent_id = new_parent.id
-    else
+      self.project_id = new_parent.project_id
+    elsif new_parent.is_a? Project
       self.deleted_from_parent_id = nil
+      self.project_id = new_parent.id
+    else
+      raise IncompatibleParentException.new("Objects can only be restored to a dds-folder or dds-project.::Perhaps you mistyped the object_kind.")
     end
   end
 end

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -40,12 +40,21 @@ class Container < ActiveRecord::Base
     self.project = self.parent.project if self.parent
   end
 
-  def set_deleted_from_parent
-    if is_deleted?
-      self.deleted_from_parent_id = self.parent_id
-      self.parent_id = nil
-    elsif is_deleted_was && !is_deleted?
+  def move_to_trashbin
+    self.is_deleted = true
+    self.deleted_from_parent_id = self.parent_id
+    self.parent_id = nil
+  end
+
+  def restore_from_trashbin(new_parent=nil)
+    self.is_deleted = false
+    if new_parent.nil?
       self.parent_id = self.deleted_from_parent_id
+      self.deleted_from_parent_id = nil
+    elsif new_parent.is_a? Folder
+      self.deleted_from_parent_id = nil
+      self.parent_id = new_parent.id
+    else
       self.deleted_from_parent_id = nil
     end
   end

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -54,8 +54,8 @@ class Container < ActiveRecord::Base
     elsif new_parent.is_a? Folder
       self.deleted_from_parent_id = nil
       self.parent_id = new_parent.id
-      self.project_id = new_parent.project_id
     elsif new_parent.is_a? Project
+      self.parent_id = nil
       self.deleted_from_parent_id = nil
       self.project_id = new_parent.id
     else

--- a/app/models/file_version.rb
+++ b/app/models/file_version.rb
@@ -12,6 +12,7 @@ class FileVersion < ActiveRecord::Base
   audited
   belongs_to :data_file
   alias parent data_file
+  alias deleted_from_parent data_file
 
   belongs_to :upload
   has_many :project_permissions, through: :data_file

--- a/app/models/folder.rb
+++ b/app/models/folder.rb
@@ -74,8 +74,6 @@ class Folder < Container
   def restore(child)
     raise TrashbinParentException.new("#{kind} #{id} is deleted, and cannot restore children.::Restore #{kind} #{id}.") if is_deleted?
     raise IncompatibleParentException.new("Folders can only restore dds-file or dds-folder objects.::Perhaps you mistyped the object_kind.") unless child.is_a? Container
-    child.parent_id = id
-    child.project_id = project_id
-    child.is_deleted = false
+    child.restore_from_trashbin self
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -100,9 +100,7 @@ class Project < ActiveRecord::Base
   def restore(child)
     raise IncompatibleParentException.new("#{kind} #{id} is permenantly deleted, and cannot restore children.::Restore to a different project.") if is_deleted?
     raise IncompatibleParentException.new("Projects can only restore dds-file or dds-folder objects.::Perhaps you mistyped the object_kind.") unless child.is_a? Container
-    child.parent_id = nil
-    child.project_id = id
-    child.is_deleted = false
+    child.restore_from_trashbin self
   end
 
   private

--- a/db/migrate/20180403120319_add_deleted_from_parent_to_containers.rb
+++ b/db/migrate/20180403120319_add_deleted_from_parent_to_containers.rb
@@ -1,0 +1,5 @@
+class AddDeletedFromParentToContainers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :containers, :deleted_from_parent_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,337 +10,338 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170926165229) do
+ActiveRecord::Schema.define(version: 20180403120319) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
   create_table "activities", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "name"
-    t.string   "description"
-    t.uuid     "creator_id"
+    t.string "name"
+    t.string "description"
+    t.uuid "creator_id"
     t.datetime "started_on"
     t.datetime "ended_on"
-    t.boolean  "is_deleted",  default: false
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.boolean "is_deleted", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "affiliations", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "project_id"
-    t.uuid     "user_id"
-    t.string   "project_role_id"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.uuid "project_id"
+    t.uuid "user_id"
+    t.string "project_role_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "api_keys", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "user_id"
-    t.uuid     "software_agent_id"
-    t.string   "key"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.uuid "user_id"
+    t.uuid "software_agent_id"
+    t.string "key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "audits", force: :cascade do |t|
-    t.uuid     "auditable_id"
-    t.string   "auditable_type"
-    t.uuid     "associated_id"
-    t.string   "associated_type"
-    t.uuid     "user_id"
-    t.string   "user_type"
-    t.string   "username"
-    t.string   "action"
-    t.text     "audited_changes"
-    t.integer  "version",         default: 0
-    t.jsonb    "comment"
-    t.string   "remote_address"
-    t.string   "request_uuid"
+  create_table "audits", id: :serial, force: :cascade do |t|
+    t.uuid "auditable_id"
+    t.string "auditable_type"
+    t.uuid "associated_id"
+    t.string "associated_type"
+    t.uuid "user_id"
+    t.string "user_type"
+    t.string "username"
+    t.string "action"
+    t.text "audited_changes"
+    t.integer "version", default: 0
+    t.jsonb "comment"
+    t.string "remote_address"
+    t.string "request_uuid"
     t.datetime "created_at"
-    t.index ["associated_id", "associated_type"], name: "associated_index", using: :btree
-    t.index ["auditable_id", "auditable_type"], name: "auditable_index", using: :btree
+    t.index ["associated_id", "associated_type"], name: "associated_index"
+    t.index ["auditable_id", "auditable_type"], name: "auditable_index"
     t.index ["comment"], name: "index_audits_on_comment", using: :gin
-    t.index ["created_at"], name: "index_audits_on_created_at", using: :btree
-    t.index ["request_uuid"], name: "index_audits_on_request_uuid", using: :btree
-    t.index ["user_id", "user_type"], name: "user_index", using: :btree
+    t.index ["created_at"], name: "index_audits_on_created_at"
+    t.index ["request_uuid"], name: "index_audits_on_request_uuid"
+    t.index ["user_id", "user_type"], name: "user_index"
   end
 
   create_table "auth_roles", id: false, force: :cascade do |t|
-    t.string   "id",                            null: false
-    t.string   "name"
-    t.string   "description"
-    t.jsonb    "permissions"
-    t.jsonb    "contexts"
-    t.boolean  "is_deprecated", default: false, null: false
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.string "id", null: false
+    t.string "name"
+    t.string "description"
+    t.jsonb "permissions"
+    t.jsonb "contexts"
+    t.boolean "is_deprecated", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["contexts"], name: "index_auth_roles_on_contexts", using: :gin
     t.index ["permissions"], name: "index_auth_roles_on_permissions", using: :gin
   end
 
   create_table "authentication_services", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "service_id"
-    t.string   "base_uri"
-    t.string   "name"
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
-    t.string   "type"
-    t.string   "client_id"
-    t.string   "client_secret"
-    t.boolean  "is_default",           default: false, null: false
-    t.string   "login_initiation_uri"
-    t.string   "login_response_type"
-    t.boolean  "is_deprecated",        default: false, null: false
-    t.integer  "identity_provider_id"
+    t.uuid "service_id"
+    t.string "base_uri"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "type"
+    t.string "client_id"
+    t.string "client_secret"
+    t.boolean "is_default", default: false, null: false
+    t.string "login_initiation_uri"
+    t.string "login_response_type"
+    t.boolean "is_deprecated", default: false, null: false
+    t.integer "identity_provider_id"
   end
 
   create_table "chunks", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "upload_id"
-    t.integer  "number"
-    t.bigint   "size"
-    t.string   "fingerprint_value"
-    t.string   "fingerprint_algorithm"
-    t.datetime "created_at",            null: false
-    t.datetime "updated_at",            null: false
-    t.index ["upload_id", "number"], name: "index_chunks_on_upload_id_and_number", using: :btree
-    t.index ["upload_id"], name: "index_chunks_on_upload_id", using: :btree
+    t.uuid "upload_id"
+    t.integer "number"
+    t.bigint "size"
+    t.string "fingerprint_value"
+    t.string "fingerprint_algorithm"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["upload_id", "number"], name: "index_chunks_on_upload_id_and_number"
+    t.index ["upload_id"], name: "index_chunks_on_upload_id"
   end
 
   create_table "containers", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "name"
-    t.string   "type"
-    t.uuid     "parent_id"
-    t.uuid     "project_id"
-    t.boolean  "is_deleted", default: false
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.string   "label"
-    t.boolean  "is_purged",  default: false
-    t.index ["id", "type"], name: "index_containers_on_id_and_type", using: :btree
-    t.index ["parent_id"], name: "index_containers_on_parent_id", using: :btree
-    t.index ["project_id", "parent_id", "is_deleted"], name: "index_containers_on_project_id_and_parent_id_and_is_deleted", using: :btree
-    t.index ["project_id"], name: "index_containers_on_project_id", using: :btree
+    t.string "name"
+    t.string "type"
+    t.uuid "parent_id"
+    t.uuid "project_id"
+    t.boolean "is_deleted", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "label"
+    t.boolean "is_purged", default: false
+    t.uuid "deleted_from_parent_id"
+    t.index ["id", "type"], name: "index_containers_on_id_and_type"
+    t.index ["parent_id"], name: "index_containers_on_parent_id"
+    t.index ["project_id", "parent_id", "is_deleted"], name: "index_containers_on_project_id_and_parent_id_and_is_deleted"
+    t.index ["project_id"], name: "index_containers_on_project_id"
   end
 
   create_table "file_versions", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "data_file_id"
-    t.integer  "version_number"
-    t.string   "label"
-    t.uuid     "upload_id"
-    t.boolean  "is_deleted",     default: false
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
-    t.boolean  "is_purged",      default: false
-    t.index ["data_file_id"], name: "index_file_versions_on_data_file_id", using: :btree
+    t.uuid "data_file_id"
+    t.integer "version_number"
+    t.string "label"
+    t.uuid "upload_id"
+    t.boolean "is_deleted", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "is_purged", default: false
+    t.index ["data_file_id"], name: "index_file_versions_on_data_file_id"
   end
 
   create_table "fingerprints", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "upload_id"
-    t.string   "algorithm"
-    t.string   "value"
+    t.uuid "upload_id"
+    t.string "algorithm"
+    t.string "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["upload_id"], name: "index_fingerprints_on_upload_id", using: :btree
+    t.index ["upload_id"], name: "index_fingerprints_on_upload_id"
   end
 
-  create_table "identity_providers", force: :cascade do |t|
-    t.string   "host"
-    t.string   "port"
-    t.string   "type"
-    t.string   "ldap_base"
+  create_table "identity_providers", id: :serial, force: :cascade do |t|
+    t.string "host"
+    t.string "port"
+    t.string "type"
+    t.string "ldap_base"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
   create_table "job_transactions", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "transactionable_type"
-    t.uuid     "transactionable_id"
-    t.string   "request_id"
-    t.string   "key"
-    t.string   "state"
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
+    t.string "transactionable_type"
+    t.uuid "transactionable_id"
+    t.string "request_id"
+    t.string "key"
+    t.string "state"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "meta_properties", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "meta_template_id"
-    t.uuid     "property_id"
-    t.string   "value"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.uuid "meta_template_id"
+    t.uuid "property_id"
+    t.string "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "meta_templates", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "templatable_id"
-    t.string   "templatable_type"
-    t.uuid     "template_id"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.uuid "templatable_id"
+    t.string "templatable_type"
+    t.uuid "template_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "project_permissions", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "project_id"
-    t.uuid     "user_id"
-    t.string   "auth_role_id"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
-    t.index ["project_id", "auth_role_id", "user_id"], name: "index_project_permissions_on_project_and_auth_role_and_user", using: :btree
+    t.uuid "project_id"
+    t.uuid "user_id"
+    t.string "auth_role_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id", "auth_role_id", "user_id"], name: "index_project_permissions_on_project_and_auth_role_and_user"
   end
 
   create_table "project_roles", id: false, force: :cascade do |t|
-    t.string   "id",                            null: false
-    t.string   "name"
-    t.string   "description"
-    t.boolean  "is_deprecated", default: false, null: false
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.string "id", null: false
+    t.string "name"
+    t.string "description"
+    t.boolean "is_deprecated", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "project_transfer_users", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "project_transfer_id"
-    t.uuid     "to_user_id"
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
+    t.uuid "project_transfer_id"
+    t.uuid "to_user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "project_transfers", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.integer  "status"
-    t.text     "status_comment"
-    t.uuid     "project_id"
-    t.uuid     "from_user_id"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.integer "status"
+    t.text "status_comment"
+    t.uuid "project_id"
+    t.uuid "from_user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "projects", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "name"
-    t.string   "description"
-    t.uuid     "creator_id"
-    t.string   "etag"
-    t.boolean  "is_deleted",    default: false
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
-    t.boolean  "is_consistent"
+    t.string "name"
+    t.string "description"
+    t.uuid "creator_id"
+    t.string "etag"
+    t.boolean "is_deleted", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "is_consistent"
   end
 
   create_table "properties", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "template_id"
-    t.string   "key"
-    t.string   "label"
-    t.text     "description"
-    t.string   "data_type"
-    t.boolean  "is_deprecated"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.uuid "template_id"
+    t.string "key"
+    t.string "label"
+    t.text "description"
+    t.string "data_type"
+    t.boolean "is_deprecated"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "prov_relations", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "type"
-    t.uuid     "creator_id"
-    t.uuid     "relatable_from_id"
-    t.string   "relatable_from_type"
-    t.string   "relationship_type"
-    t.uuid     "relatable_to_id"
-    t.string   "relatable_to_type"
-    t.boolean  "is_deleted",          default: false
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
-    t.index ["relatable_from_id"], name: "index_prov_relations_on_relatable_from_id", using: :btree
-    t.index ["relatable_to_id"], name: "index_prov_relations_on_relatable_to_id", using: :btree
+    t.string "type"
+    t.uuid "creator_id"
+    t.uuid "relatable_from_id"
+    t.string "relatable_from_type"
+    t.string "relationship_type"
+    t.uuid "relatable_to_id"
+    t.string "relatable_to_type"
+    t.boolean "is_deleted", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["relatable_from_id"], name: "index_prov_relations_on_relatable_from_id"
+    t.index ["relatable_to_id"], name: "index_prov_relations_on_relatable_to_id"
   end
 
   create_table "software_agents", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "name"
-    t.string   "description"
-    t.uuid     "creator_id"
-    t.string   "repo_url"
-    t.boolean  "is_deleted",  default: false
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.string "name"
+    t.string "description"
+    t.uuid "creator_id"
+    t.string "repo_url"
+    t.boolean "is_deleted", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "storage_providers", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "display_name"
-    t.string   "description"
-    t.string   "name"
-    t.string   "url_root"
-    t.string   "provider_version"
-    t.string   "auth_uri"
-    t.string   "service_user"
-    t.string   "service_pass"
-    t.string   "primary_key"
-    t.string   "secondary_key"
-    t.boolean  "is_deprecated",        default: false, null: false
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
-    t.string   "chunk_hash_algorithm", default: "md5"
-    t.integer  "chunk_max_number"
-    t.bigint   "chunk_max_size_bytes"
+    t.string "display_name"
+    t.string "description"
+    t.string "name"
+    t.string "url_root"
+    t.string "provider_version"
+    t.string "auth_uri"
+    t.string "service_user"
+    t.string "service_pass"
+    t.string "primary_key"
+    t.string "secondary_key"
+    t.boolean "is_deprecated", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "chunk_hash_algorithm", default: "md5"
+    t.integer "chunk_max_number"
+    t.bigint "chunk_max_size_bytes"
   end
 
   create_table "system_permissions", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "user_id"
-    t.string   "auth_role_id"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.uuid "user_id"
+    t.string "auth_role_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "tags", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "label"
-    t.string   "taggable_type"
-    t.uuid     "taggable_id"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.string "label"
+    t.string "taggable_type"
+    t.uuid "taggable_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "templates", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "name"
-    t.string   "label"
-    t.text     "description"
-    t.boolean  "is_deprecated", default: false
-    t.uuid     "creator_id"
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.string "name"
+    t.string "label"
+    t.text "description"
+    t.boolean "is_deprecated", default: false
+    t.uuid "creator_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "uploads", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "project_id"
-    t.string   "name"
-    t.string   "content_type"
-    t.bigint   "size"
-    t.string   "fingerprint_value"
-    t.string   "fingerprint_algorithm"
-    t.uuid     "storage_provider_id"
+    t.uuid "project_id"
+    t.string "name"
+    t.string "content_type"
+    t.bigint "size"
+    t.string "fingerprint_value"
+    t.string "fingerprint_algorithm"
+    t.uuid "storage_provider_id"
     t.datetime "error_at"
-    t.string   "error_message"
+    t.string "error_message"
     t.datetime "completed_at"
-    t.string   "etag"
-    t.datetime "created_at",            null: false
-    t.datetime "updated_at",            null: false
-    t.uuid     "creator_id"
-    t.boolean  "is_consistent"
-    t.string   "storage_container"
+    t.string "etag"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "creator_id"
+    t.boolean "is_consistent"
+    t.string "storage_container"
   end
 
   create_table "user_authentication_services", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "user_id"
-    t.uuid     "authentication_service_id"
-    t.string   "uid"
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.uuid "user_id"
+    t.uuid "authentication_service_id"
+    t.string "uid"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "username"
-    t.string   "etag"
-    t.string   "email"
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "display_name"
+    t.string "username"
+    t.string "etag"
+    t.string "email"
+    t.string "first_name"
+    t.string "last_name"
+    t.string "display_name"
     t.datetime "last_login_at"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/spec/models/data_file_spec.rb
+++ b/spec/models/data_file_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe DataFile, type: :model do
       let(:original_parent) { subject.deleted_from_parent }
       it {
         subject.move_to_trashbin
-        subject.save
+        expect(subject.save).to be_truthy
 
         expect(subject.is_deleted?).to be_truthy
         expect(subject.parent_id).to be_nil
@@ -316,7 +316,7 @@ RSpec.describe DataFile, type: :model do
         let(:original_parent) { subject.deleted_from_parent }
         it {
           subject.move_to_trashbin
-          subject.save
+          expect(subject.save).to be_truthy
 
           expect(subject.is_deleted?).to be_truthy
           expect(subject.parent_id).to be_nil
@@ -342,7 +342,7 @@ RSpec.describe DataFile, type: :model do
         let(:original_parent) { subject.deleted_from_parent }
         it {
           subject.move_to_trashbin
-          subject.save
+          expect(subject.save).to be_truthy
 
           expect(subject.is_deleted?).to be_truthy
           expect(subject.parent_id).to be_nil
@@ -368,7 +368,7 @@ RSpec.describe DataFile, type: :model do
       let(:target_project) { project }
       it {
         subject.move_to_trashbin
-        subject.save
+        expect(subject.save).to be_truthy
 
         expect(subject.is_deleted?).to be_truthy
         expect(subject.parent_id).to be_nil
@@ -392,7 +392,7 @@ RSpec.describe DataFile, type: :model do
       let(:target_project) { other_project }
       it {
         subject.move_to_trashbin
-        subject.save
+        expect(subject.save).to be_truthy
 
         expect(subject.is_deleted?).to be_truthy
         expect(subject.parent_id).to be_nil
@@ -416,7 +416,7 @@ RSpec.describe DataFile, type: :model do
       let(:new_parent) { file_versions.first }
       it {
         subject.move_to_trashbin
-        subject.save
+        expect(subject.save).to be_truthy
 
         expect {
           subject.restore_from_trashbin new_parent

--- a/spec/models/data_file_spec.rb
+++ b/spec/models/data_file_spec.rb
@@ -262,14 +262,13 @@ RSpec.describe DataFile, type: :model do
       end
     end
 
-    describe '.move_to_trashbin' do
+    describe '#move_to_trashbin' do
+      let(:original_parent) { subject.parent }
       it { is_expected.to respond_to(:move_to_trashbin) }
 
       subject { child_file }
       it {
-        expect(subject.parent_id).not_to be_nil
-        expect(subject.parent).not_to be_nil
-        original_parent = subject.parent
+        expect(original_parent).not_to be_nil
         expect(subject.deleted_from_parent_id).to be_nil
         expect(subject.deleted_from_parent).to be_nil
         expect(subject.is_deleted?).to be_falsey
@@ -286,10 +285,11 @@ RSpec.describe DataFile, type: :model do
     end
   end
 
-  describe '.restore_from_trashbin' do
+  describe '#restore_from_trashbin' do
     it { is_expected.to respond_to(:restore_from_trashbin) }
 
     context 'to original parent' do
+      let(:original_parent) { subject.deleted_from_parent }
       it {
         subject.move_to_trashbin
         subject.save
@@ -297,9 +297,7 @@ RSpec.describe DataFile, type: :model do
         expect(subject.is_deleted?).to be_truthy
         expect(subject.parent_id).to be_nil
         expect(subject.parent).to be_nil
-        expect(subject.deleted_from_parent_id).not_to be_nil
-        expect(subject.deleted_from_parent).not_to be_nil
-        original_parent = subject.deleted_from_parent
+        expect(original_parent).not_to be_nil
 
         subject.restore_from_trashbin
 
@@ -313,7 +311,61 @@ RSpec.describe DataFile, type: :model do
     end
 
     context 'to new parent folder' do
-      let(:new_parent) { other_folder }
+      context 'in original project' do
+        let(:new_parent) { FactoryBot.create(:folder, project: project) }
+        let(:original_parent) { subject.deleted_from_parent }
+        it {
+          subject.move_to_trashbin
+          subject.save
+
+          expect(subject.is_deleted?).to be_truthy
+          expect(subject.parent_id).to be_nil
+          expect(subject.parent).to be_nil
+          expect(original_parent).not_to be_nil
+
+          subject.restore_from_trashbin new_parent
+
+          expect(subject.is_deleted?).to be_falsey
+          expect(subject.parent_id).not_to be_nil
+          expect(subject.parent).not_to be_nil
+          expect(subject.deleted_from_parent_id).to be_nil
+          expect(subject.deleted_from_parent).to be_nil
+          expect(subject.parent).not_to eq(original_parent)
+          expect(subject.parent).to eq(new_parent)
+          expect(subject.project_id).to eq(new_parent.project_id)
+          expect(subject).to be_valid
+        }
+      end
+
+      context 'in different project' do
+        let(:new_parent) { other_folder }
+        let(:original_parent) { subject.deleted_from_parent }
+        it {
+          subject.move_to_trashbin
+          subject.save
+
+          expect(subject.is_deleted?).to be_truthy
+          expect(subject.parent_id).to be_nil
+          expect(subject.parent).to be_nil
+          expect(original_parent).not_to be_nil
+
+          subject.restore_from_trashbin new_parent
+
+          expect(subject.is_deleted?).to be_falsey
+          expect(subject.parent_id).not_to be_nil
+          expect(subject.parent).not_to be_nil
+          expect(subject.deleted_from_parent_id).to be_nil
+          expect(subject.deleted_from_parent).to be_nil
+          expect(subject.parent).not_to eq(original_parent)
+          expect(subject.parent).to eq(new_parent)
+          expect(subject.project_id).to eq(new_parent.project_id)
+          expect(subject).not_to be_valid
+        }
+      end
+    end
+
+    context 'to original project root' do
+      let(:target_project) { project }
       it {
         subject.move_to_trashbin
         subject.save
@@ -323,21 +375,21 @@ RSpec.describe DataFile, type: :model do
         expect(subject.parent).to be_nil
         expect(subject.deleted_from_parent_id).not_to be_nil
         expect(subject.deleted_from_parent).not_to be_nil
-        original_parent = subject.deleted_from_parent
 
-        subject.restore_from_trashbin(other_folder)
+        subject.restore_from_trashbin target_project
 
         expect(subject.is_deleted?).to be_falsey
-        expect(subject.parent_id).not_to be_nil
-        expect(subject.parent).not_to be_nil
+        expect(subject.parent_id).to be_nil
+        expect(subject.parent).to be_nil
         expect(subject.deleted_from_parent_id).to be_nil
         expect(subject.deleted_from_parent).to be_nil
-        expect(subject.parent).not_to eq(original_parent)
-        expect(subject.parent).to eq(new_parent)
+        expect(subject.project_id).to eq(target_project.id)
+        expect(subject).to be_valid
       }
     end
 
-    context 'to project root' do
+    context 'to different project root' do
+      let(:target_project) { other_project }
       it {
         subject.move_to_trashbin
         subject.save
@@ -348,13 +400,27 @@ RSpec.describe DataFile, type: :model do
         expect(subject.deleted_from_parent_id).not_to be_nil
         expect(subject.deleted_from_parent).not_to be_nil
 
-        subject.restore_from_trashbin(project)
+        subject.restore_from_trashbin target_project
 
         expect(subject.is_deleted?).to be_falsey
         expect(subject.parent_id).to be_nil
         expect(subject.parent).to be_nil
         expect(subject.deleted_from_parent_id).to be_nil
         expect(subject.deleted_from_parent).to be_nil
+        expect(subject.project_id).to eq(target_project.id)
+        expect(subject).not_to be_valid
+      }
+    end
+
+    context 'to non project or folder' do
+      let(:new_parent) { file_versions.first }
+      it {
+        subject.move_to_trashbin
+        subject.save
+
+        expect {
+          subject.restore_from_trashbin new_parent
+        }.to raise_error(IncompatibleParentException)
       }
     end
   end

--- a/spec/models/data_file_spec.rb
+++ b/spec/models/data_file_spec.rb
@@ -300,18 +300,34 @@ RSpec.describe DataFile, type: :model do
     end
 
     context 'to original parent' do
+      context 'folder' do
+        it {
+          subject.restore_from_trashbin
 
+          expect(subject.is_deleted?).to be_falsey
+          expect(subject.parent_id).not_to be_nil
+          expect(subject.parent).not_to be_nil
+          expect(subject.deleted_from_parent_id).to be_nil
+          expect(subject.deleted_from_parent).to be_nil
+          expect(subject.parent).to eq(original_parent)
+        }
+      end
 
-      it {
-        subject.restore_from_trashbin
+      context 'project' do
+        subject { root_file }
+        let(:original_parent) { root_file.project }
 
-        expect(subject.is_deleted?).to be_falsey
-        expect(subject.parent_id).not_to be_nil
-        expect(subject.parent).not_to be_nil
-        expect(subject.deleted_from_parent_id).to be_nil
-        expect(subject.deleted_from_parent).to be_nil
-        expect(subject.parent).to eq(original_parent)
-      }
+        it {
+          subject.restore_from_trashbin
+
+          expect(subject.is_deleted?).to be_falsey
+          expect(subject.parent_id).to be_nil
+          expect(subject.parent).to be_nil
+          expect(subject.deleted_from_parent_id).to be_nil
+          expect(subject.deleted_from_parent).to be_nil
+          expect(subject.project).to eq(original_parent)
+        }
+      end
     end
 
     context 'to new parent folder' do

--- a/spec/models/folder_spec.rb
+++ b/spec/models/folder_spec.rb
@@ -318,16 +318,34 @@ RSpec.describe Folder, type: :model do
     end
 
     context 'to original parent' do
-      it {
-        subject.restore_from_trashbin
+      context 'folder' do
+        it {
+          subject.restore_from_trashbin
 
-        expect(subject.is_deleted?).to be_falsey
-        expect(subject.parent_id).not_to be_nil
-        expect(subject.parent).not_to be_nil
-        expect(subject.deleted_from_parent_id).to be_nil
-        expect(subject.deleted_from_parent).to be_nil
-        expect(subject.parent).to eq(original_parent)
-      }
+          expect(subject.is_deleted?).to be_falsey
+          expect(subject.parent_id).not_to be_nil
+          expect(subject.parent).not_to be_nil
+          expect(subject.deleted_from_parent_id).to be_nil
+          expect(subject.deleted_from_parent).to be_nil
+          expect(subject.parent).to eq(original_parent)
+        }
+      end
+
+      context 'project' do
+        subject { other_folder }
+        let(:original_parent) { subject.project }
+
+        it {
+          subject.restore_from_trashbin
+
+          expect(subject.is_deleted?).to be_falsey
+          expect(subject.parent_id).to be_nil
+          expect(subject.parent).to be_nil
+          expect(subject.deleted_from_parent_id).to be_nil
+          expect(subject.deleted_from_parent).to be_nil
+          expect(subject.project).to eq(original_parent)
+        }
+      end
     end
 
     context 'to new parent folder' do

--- a/spec/models/folder_spec.rb
+++ b/spec/models/folder_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe Folder, type: :model do
     context 'is_deleted? true' do
       before do
         subject.move_to_trashbin
-        subject.save
+        expect(subject.save).to be_truthy
       end
       it {
         expect {
@@ -232,7 +232,7 @@ RSpec.describe Folder, type: :model do
     context 'when child is a Container' do
       before do
         child.move_to_trashbin
-        child.save
+        expect(child.save).to be_truthy
         child.reload
       end
       context 'from another folder' do
@@ -279,7 +279,7 @@ RSpec.describe Folder, type: :model do
     context 'deleted' do
       before do
         subject.move_to_trashbin
-        subject.save
+        expect(subject.save).to be_truthy
         subject.reload
       end
       it {
@@ -319,7 +319,7 @@ RSpec.describe Folder, type: :model do
       let(:original_parent) { subject.deleted_from_parent }
       it {
         subject.move_to_trashbin
-        subject.save
+        expect(subject.save).to be_truthy
 
         expect(subject.is_deleted?).to be_truthy
         expect(subject.parent_id).to be_nil
@@ -344,7 +344,7 @@ RSpec.describe Folder, type: :model do
         let(:new_parent) { FactoryBot.create(:folder, project: project) }
         it {
           subject.move_to_trashbin
-          subject.save
+          expect(subject.save).to be_truthy
 
           expect(subject.is_deleted?).to be_truthy
           expect(subject.parent_id).to be_nil
@@ -371,7 +371,7 @@ RSpec.describe Folder, type: :model do
 
         it {
           subject.move_to_trashbin
-          subject.save
+          expect(subject.save).to be_truthy
 
           expect(subject.is_deleted?).to be_truthy
           expect(subject.parent_id).to be_nil
@@ -397,7 +397,7 @@ RSpec.describe Folder, type: :model do
       let(:target_project) { project }
       it {
         subject.move_to_trashbin
-        subject.save
+        expect(subject.save).to be_truthy
 
         expect(subject.is_deleted?).to be_truthy
         expect(subject.parent_id).to be_nil
@@ -421,7 +421,7 @@ RSpec.describe Folder, type: :model do
       let(:target_project) { other_project }
       it {
         subject.move_to_trashbin
-        subject.save
+        expect(subject.save).to be_truthy
 
         expect(subject.is_deleted?).to be_truthy
         expect(subject.parent_id).to be_nil
@@ -445,7 +445,7 @@ RSpec.describe Folder, type: :model do
       let(:new_parent) { immediate_child_file }
       it {
         subject.move_to_trashbin
-        subject.save
+        expect(subject.save).to be_truthy
 
         expect {
           subject.restore_from_trashbin new_parent

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -372,7 +372,7 @@ RSpec.describe Project, type: :model do
       }
     end #purge_children
 
-    describe '.restore' do
+    describe '#restore' do
       context 'is_deleted? true' do
         before do
           subject.update_columns(is_deleted: true)

--- a/spec/requests/files_api_spec.rb
+++ b/spec/requests/files_api_spec.rb
@@ -379,18 +379,44 @@ describe DDS::V1::FilesAPI do
     describe 'DELETE' do
       subject { delete(url, headers: headers) }
       let(:called_action) { 'DELETE' }
-      it_behaves_like 'a removable resource' do
-        let(:resource_counter) { resource_class.where(is_deleted: false) }
 
-        it 'should be marked as deleted' do
-          expect(resource).to be_persisted
-          is_expected.to eq(204)
-          resource.reload
-          expect(resource.is_deleted?).to be_truthy
+      context 'root data_file' do
+        it_behaves_like 'a removable resource' do
+          let(:resource_counter) { resource_class.where(is_deleted: false) }
+
+          it 'should be marked as deleted' do
+            expect(resource).to be_persisted
+            is_expected.to eq(204)
+            resource.reload
+            expect(resource.is_deleted?).to be_truthy
+          end
+
+          it_behaves_like 'an identified resource' do
+            let(:resource_id) {'notfoundid'}
+          end
         end
+      end
 
-        it_behaves_like 'an identified resource' do
-          let(:resource_id) {'notfoundid'}
+      context 'folder child file' do
+        let(:resource) { FactoryBot.create(:data_file, project: project, upload: upload, parent: folder) }
+
+        it_behaves_like 'a removable resource' do
+          let(:resource_counter) { resource_class.where(is_deleted: false) }
+
+          it 'should be marked as deleted and moved to the root of the project' do
+            expect(resource).to be_persisted
+            expect(resource.parent).not_to be_nil
+            expect(resource.deleted_from_parent).to be_nil
+            original_parent = resource.parent
+
+            is_expected.to eq(204)
+
+            resource.reload
+            expect(resource.is_deleted?).to be_truthy
+            expect(resource.parent).to be_nil
+            expect(resource.deleted_from_parent).not_to be_nil
+            expect(resource.deleted_from_parent).to eq original_parent
+          end
         end
       end
 

--- a/spec/requests/trashbin_api_spec.rb
+++ b/spec/requests/trashbin_api_spec.rb
@@ -82,8 +82,8 @@ describe DDS::V1::TrashbinAPI do
       end
 
       context 'without payload' do
-        context 'resource in root of the project' do
-          it_behaves_like 'a PUT request' do
+        it_behaves_like 'a PUT request' do
+          context 'resource in root of the project' do
             it_behaves_like 'an identified resource' do
               let(:resource_id) { "doesNotExist" }
             end
@@ -133,38 +133,38 @@ describe DDS::V1::TrashbinAPI do
               end
             end
           end
-        end
 
-        context 'resource in a folder' do
-          let(:resource) { trashed_child_resource }
-          let(:resource_kind) { trashed_child_resource.kind }
-          let(:resource_id) { trashed_child_resource.id }
+          context 'resource in a folder' do
+            let(:resource) { trashed_child_resource }
+            let(:resource_kind) { trashed_child_resource.kind }
+            let(:resource_id) { trashed_child_resource.id }
 
-          before do
-            expect(parent_folder).to be_persisted
-          end
-
-          context 'that is deleted' do
             before do
-              pf = resource.deleted_from_parent
-              pf.move_to_trashbin
-              pf.save
+              expect(parent_folder).to be_persisted
             end
-            it_behaves_like 'a client error' do
-              let(:expected_response) { 404 }
-              let(:expected_reason) { "dds-folder #{parent_folder.id} is deleted, and cannot restore children." }
-              let(:expected_suggestion) { "Restore #{parent_folder.kind} #{parent_folder.id}." }
-            end
-          end
 
-          it_behaves_like 'an updatable resource' do
-            it 'restores the object' do
-              original_parent = resource.deleted_from_parent
-              is_expected.to eq(expected_response_status)
-              resource.reload
-              expect(resource.is_deleted?).to be_falsey
-              expect(resource.parent).to eq original_parent
-              expect(resource.deleted_from_parent_id).to be_nil
+            context 'that is deleted' do
+              before do
+                pf = resource.deleted_from_parent
+                pf.move_to_trashbin
+                pf.save
+              end
+              it_behaves_like 'a client error' do
+                let(:expected_response) { 404 }
+                let(:expected_reason) { "dds-folder #{parent_folder.id} is deleted, and cannot restore children." }
+                let(:expected_suggestion) { "Restore #{parent_folder.kind} #{parent_folder.id}." }
+              end
+            end
+
+            it_behaves_like 'an updatable resource' do
+              it 'restores the object' do
+                original_parent = resource.deleted_from_parent
+                is_expected.to eq(expected_response_status)
+                resource.reload
+                expect(resource.is_deleted?).to be_falsey
+                expect(resource.parent).to eq original_parent
+                expect(resource.deleted_from_parent_id).to be_nil
+              end
             end
           end
         end

--- a/spec/requests/trashbin_api_spec.rb
+++ b/spec/requests/trashbin_api_spec.rb
@@ -81,8 +81,8 @@ describe DDS::V1::TrashbinAPI do
         resource.save
       end
 
-      context 'without payload' do
-        it_behaves_like 'a PUT request' do
+      it_behaves_like 'a PUT request' do
+        context 'without payload' do
           context 'resource in root of the project' do
             it_behaves_like 'an identified resource' do
               let(:resource_id) { "doesNotExist" }
@@ -168,68 +168,67 @@ describe DDS::V1::TrashbinAPI do
             end
           end
         end
-      end
 
-      context 'with payload' do
-        subject { put(url, params: payload.to_json, headers: headers) }
-        let(:payload) {{
-          parent: {
-            kind: parent_kind,
-            id: parent_id
-          }
-        }}
+        context 'with payload' do
+          let(:payload) {{
+            parent: {
+              kind: parent_kind,
+              id: parent_id
+            }
+          }}
 
-        context 'for parent in same project' do
-          it_behaves_like 'an authorized resource'
+          context 'for parent in same project' do
+            it_behaves_like 'an authorized resource'
 
-          it_behaves_like 'an identified resource' do
-            let(:parent_id) { "doesNotExist" }
-            let(:resource_class) { Folder }
-          end
+            it_behaves_like 'an identified resource' do
+              let(:parent_id) { "doesNotExist" }
+              let(:resource_class) { Folder }
+            end
 
-          it_behaves_like 'a kinded resource' do
-            let(:parent_kind) { 'invalid-kind' }
-            let(:resource_kind) { 'invalid-kind' }
-          end
+            it_behaves_like 'a kinded resource' do
+              let(:parent_kind) { 'invalid-kind' }
+              let(:resource_kind) { 'invalid-kind' }
+            end
 
-          it_behaves_like 'an updatable resource' do
-            it 'restores the object' do
-              original_parent = resource.deleted_from_parent
-              is_expected.to eq(expected_response_status)
-              resource.reload
-              expect(resource.is_deleted?).to be_falsey
-              expect(resource.parent).not_to eq original_parent
-              expect(resource.parent).to eq parent_folder
-              expect(resource.deleted_from_parent_id).to be_nil
+            it_behaves_like 'an updatable resource' do
+              it 'restores the object' do
+                original_parent = resource.deleted_from_parent
+                is_expected.to eq(expected_response_status)
+                resource.reload
+                expect(resource.is_deleted?).to be_falsey
+                expect(resource.parent).not_to eq original_parent
+                expect(resource.parent).to eq parent_folder
+                expect(resource.deleted_from_parent_id).to be_nil
+              end
             end
           end
-        end
 
-        context 'for parent in different project' do
-          let(:other_project_folder) { FactoryBot.create(:folder, project: other_permission.project) }
-          let(:parent_kind) { other_project_folder.kind }
-          let(:parent_id) { other_project_folder.id }
+          context 'for parent in different project' do
+            let(:other_project_folder) { FactoryBot.create(:folder, project: other_permission.project) }
+            let(:parent_kind) { other_project_folder.kind }
+            let(:parent_id) { other_project_folder.id }
 
-          before do
-            expect(other_project_folder).to be_persisted
+            before do
+              expect(other_project_folder).to be_persisted
+            end
+
+            it_behaves_like 'an authorized resource'
+            it_behaves_like 'an authorized resource' do
+              let(:resource_permission) { other_permission }
+            end
+
+            it_behaves_like 'an identified resource' do
+              let(:parent_id) { "doesNotExist" }
+              let(:resource_class) { Folder }
+            end
+
+            it_behaves_like 'a kinded resource' do
+              let(:parent_kind) { 'invalid-kind' }
+              let(:resource_kind) { 'invalid-kind' }
+            end
+
+            it_behaves_like 'a validated resource'
           end
-
-          it_behaves_like 'an authorized resource'
-          it_behaves_like 'an authorized resource' do
-            let(:resource_permission) { other_permission }
-          end
-
-          it_behaves_like 'an identified resource' do
-            let(:parent_id) { "doesNotExist" }
-            let(:resource_class) { Folder }
-          end
-
-          it_behaves_like 'a kinded resource' do
-            let(:parent_kind) { 'invalid-kind' }
-            let(:resource_kind) { 'invalid-kind' }
-          end
-
-          it_behaves_like 'a validated resource'
         end
       end
     end

--- a/spec/requests/trashbin_api_spec.rb
+++ b/spec/requests/trashbin_api_spec.rb
@@ -323,14 +323,6 @@ describe DDS::V1::TrashbinAPI do
         let(:resource_id) { untrashed_resource.id }
       end
 
-      it_behaves_like 'a client error' do
-        let(:resource_kind) { trashed_file_version.kind }
-        let(:resource_id) { trashed_file_version.id }
-        let(:expected_response) { 404 }
-        let(:expected_reason) { "#{trashed_file_version.kind} Not Purgable" }
-        let(:expected_suggestion) { "#{trashed_file_version.kind} is not Purgable" }
-      end
-
       it_behaves_like 'a kinded resource' do
         let(:resource_kind) { 'invalid-kind' }
       end
@@ -360,7 +352,18 @@ describe DDS::V1::TrashbinAPI do
         end
       end
 
-      context 'object is not Purgable' do
+      context 'object Not Purgable' do
+        let(:resource_kind) { trashed_file_version.kind }
+        let(:resource_id) { trashed_file_version.id }
+
+        it_behaves_like 'a client error' do
+          let(:expected_response) { 404 }
+          let(:expected_reason) { "#{resource_kind} Not Purgable" }
+          let(:expected_suggestion) { "#{resource_kind} is not Purgable" }
+        end
+      end
+
+      context 'deleted project' do
         let(:resource) { project }
         let(:resource_id) { project.id }
         let(:resource_kind) { project.kind }
@@ -375,7 +378,7 @@ describe DDS::V1::TrashbinAPI do
         end
       end
 
-      context 'already purged object' do
+      context 'already purged container' do
         let(:resource) { purged_resource }
         let(:resource_id) { purged_resource.id }
         let(:resource_kind) { purged_resource.kind }

--- a/spec/requests/trashbin_api_spec.rb
+++ b/spec/requests/trashbin_api_spec.rb
@@ -64,7 +64,7 @@ describe DDS::V1::TrashbinAPI do
 
   describe 'PUT /trashbin/{object_kind}/{object_id}/restore' do
     let(:url) { "/api/v1/trashbin/#{resource_kind}/#{resource_id}/restore" }
-    let(:called_action) { 'PUT' }
+    let(:payload) {{}}
 
     context 'container object' do
       let(:parent_kind) { parent_folder.kind }
@@ -82,54 +82,54 @@ describe DDS::V1::TrashbinAPI do
       end
 
       context 'without payload' do
-        subject { put(url, headers: headers) }
-
         context 'resource in root of the project' do
-          it_behaves_like 'an identified resource' do
-            let(:resource_id) { "doesNotExist" }
-          end
-
-          it_behaves_like 'an identified resource' do
-            let(:resource_id) { untrashed_resource.id }
-          end
-
-          context 'that is deleted' do
-            before do
-              project.update_columns(is_deleted: true)
-            end
-            it_behaves_like 'a client error' do
-              let(:expected_response) { 404 }
-              let(:expected_reason) { "dds-project #{project.id} is permenantly deleted, and cannot restore children." }
-              let(:expected_suggestion) { "Restore to a different project." }
-            end
-          end
-
-          it_behaves_like 'a kinded resource' do
-            let(:resource_kind) { 'invalid-kind' }
-          end
-
-          it_behaves_like 'an authenticated resource'
-          it_behaves_like 'an authorized resource'
-          it_behaves_like 'an annotate_audits endpoint'
-
-          it_behaves_like 'an updatable resource' do
-            it 'restores the object' do
-              is_expected.to eq(expected_response_status)
-              trashed_resource.reload
-              expect(trashed_resource.is_deleted?).to be_falsey
-              expect(trashed_resource.parent_id).to be_nil
-              expect(trashed_resource.deleted_from_parent_id).to be_nil
+          it_behaves_like 'a PUT request' do
+            it_behaves_like 'an identified resource' do
+              let(:resource_id) { "doesNotExist" }
             end
 
-            it_behaves_like 'a software_agent accessible resource' do
+            it_behaves_like 'an identified resource' do
+              let(:resource_id) { untrashed_resource.id }
+            end
+
+            context 'that is deleted' do
+              before do
+                project.update_columns(is_deleted: true)
+              end
+              it_behaves_like 'a client error' do
+                let(:expected_response) { 404 }
+                let(:expected_reason) { "dds-project #{project.id} is permenantly deleted, and cannot restore children." }
+                let(:expected_suggestion) { "Restore to a different project." }
+              end
+            end
+
+            it_behaves_like 'a kinded resource' do
+              let(:resource_kind) { 'invalid-kind' }
+            end
+
+            it_behaves_like 'an authenticated resource'
+            it_behaves_like 'an authorized resource'
+            it_behaves_like 'an annotate_audits endpoint'
+
+            it_behaves_like 'an updatable resource' do
               it 'restores the object' do
                 is_expected.to eq(expected_response_status)
                 trashed_resource.reload
                 expect(trashed_resource.is_deleted?).to be_falsey
+                expect(trashed_resource.parent_id).to be_nil
+                expect(trashed_resource.deleted_from_parent_id).to be_nil
               end
 
-              it_behaves_like 'an annotate_audits endpoint' do
-                  let(:expected_audits) { 1 }
+              it_behaves_like 'a software_agent accessible resource' do
+                it 'restores the object' do
+                  is_expected.to eq(expected_response_status)
+                  trashed_resource.reload
+                  expect(trashed_resource.is_deleted?).to be_falsey
+                end
+
+                it_behaves_like 'an annotate_audits endpoint' do
+                    let(:expected_audits) { 1 }
+                end
               end
             end
           end

--- a/spec/support/models_shared_examples.rb
+++ b/spec/support/models_shared_examples.rb
@@ -131,3 +131,11 @@ shared_context 'with concurrent calls' do |object_list:, method:|
     threads.each(&:join)
   end
 end
+
+shared_context 'trashed resource' do |resource_sym=nil|
+  let(:resource_to_trash) { resource_sym.nil? ? subject : send(resource_sym) }
+  before do
+    resource_to_trash.move_to_trashbin
+    expect(resource_to_trash.save).to be_truthy
+  end
+end


### PR DESCRIPTION
When a Folder or DataFile is deleted, it is moved to the root of the project trashbin, but its original parent is preserved for future restores.
