### PR TITLE
No More Cross Project Restores

### DIFF
--- a/api_design/DDS-829-trash_bin.md
+++ b/api_design/DDS-829-trash_bin.md
@@ -75,7 +75,7 @@ create\_file or system\_admin
 * 404: Object not found in trash bin
 
 ###### Request Parameters
-**parent.kind (string, optional)** - The kind of parent object; this can be a project (`dds-project`) or folder (`dds-folder`).
+**parent.kind (string, optional)** - The kind of parent object; this can only be a project (`dds-project`) or folder (`dds-folder`). Objects can only be restored to their original project, or to a folder in their original project.
 **parent.id (string, optional)** - The unique id of the parent.
 
 ###### Rules


### PR DESCRIPTION
Changed to reflect that /restore will not let users restore to a different project from the original project of the deleted object.