### PR TITLE
Deploy v1.5.8 to production

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,7 @@ GEM
     concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.3)
+    crass (1.0.4)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
@@ -161,7 +161,7 @@ GEM
     kaminari-grape (1.0.1)
       grape
       kaminari-core (~> 1.0)
-    loofah (2.2.1)
+    loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
@@ -243,8 +243,8 @@ GEM
       activesupport (>= 3.2)
       choice (~> 0.2.0)
       ruby-graphviz (~> 1.2)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging


### PR DESCRIPTION
Upgrading rails-html-sanitizer gem to address vulnerability CVE-2018-3741