### PR TITLE
DDS-1141-NeedlessProjectUpdates

### DIFF
--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -2,7 +2,7 @@ class Affiliation < ActiveRecord::Base
   include RequestAudited
   default_scope { order('created_at DESC') }
   audited
-  after_save :update_project_etag
+  after_save :update_project_etag, if: :saved_changes?
   after_destroy :update_project_etag
 
   belongs_to :user

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -1,9 +1,8 @@
 class Affiliation < ActiveRecord::Base
   include RequestAudited
+  include ProjectUpdater
   default_scope { order('created_at DESC') }
   audited
-  after_save :update_project_etag, if: :saved_changes?
-  after_destroy :update_project_etag
 
   belongs_to :user
   belongs_to :project
@@ -13,14 +12,4 @@ class Affiliation < ActiveRecord::Base
   validates :user_id, presence: true, uniqueness: {scope: :project_id, case_sensitive: false}
   validates :project_id, presence: true
   validates :project_role_id, presence: true
-
-  private
-
-  def update_project_etag
-    last_audit = self.audits.last
-    new_comment = last_audit.comment ? last_audit.comment.merge({raised_by_audit: last_audit.id}) : {raised_by_audit: last_audit.id}
-    self.project.update(etag: SecureRandom.hex)
-    last_parent_audit = self.project.audits.last
-    last_parent_audit.update(request_uuid: last_audit.request_uuid, comment: new_comment)
-  end
 end

--- a/app/models/concerns/project_updater.rb
+++ b/app/models/concerns/project_updater.rb
@@ -1,0 +1,16 @@
+module ProjectUpdater
+  extend ActiveSupport::Concern
+
+  included do
+    after_save :update_project_etag, if: :saved_changes?
+    after_destroy :update_project_etag
+  end
+
+  def update_project_etag
+    last_audit = self.audits.last
+    new_comment = last_audit.comment ? last_audit.comment.merge({raised_by_audit: last_audit.id}) : {raised_by_audit: last_audit.id}
+    self.project.update(etag: SecureRandom.hex)
+    last_parent_audit = self.project.audits.last
+    last_parent_audit.update(request_uuid: last_audit.request_uuid, comment: new_comment)
+  end
+end

--- a/app/models/project_permission.rb
+++ b/app/models/project_permission.rb
@@ -1,9 +1,8 @@
 class ProjectPermission < ActiveRecord::Base
   include RequestAudited
+  include ProjectUpdater
   default_scope { order('created_at DESC') }
   audited
-  after_save :update_project_etag, if: :saved_changes?
-  after_destroy :update_project_etag
 
   belongs_to :user
   belongs_to :project
@@ -13,14 +12,4 @@ class ProjectPermission < ActiveRecord::Base
   validates :user_id, presence: true, uniqueness: {scope: :project_id, case_sensitive: false}
   validates :project_id, presence: true
   validates :auth_role_id, presence: true
-
-  private
-
-  def update_project_etag
-    last_audit = self.audits.last
-    new_comment = last_audit.comment ? last_audit.comment.merge({raised_by_audit: last_audit.id}) : {raised_by_audit: last_audit.id}
-    self.project.update(etag: SecureRandom.hex, audit_comment: new_comment)
-    last_parent_audit = self.project.audits.last
-    last_parent_audit.update(request_uuid: last_audit.request_uuid)
-  end
 end

--- a/app/models/project_permission.rb
+++ b/app/models/project_permission.rb
@@ -17,10 +17,12 @@ class ProjectPermission < ActiveRecord::Base
   private
 
   def update_project_etag
-    last_audit = self.audits.last
-    new_comment = last_audit.comment ? last_audit.comment.merge({raised_by_audit: last_audit.id}) : {raised_by_audit: last_audit.id}
-    self.project.update(etag: SecureRandom.hex, audit_comment: new_comment)
-    last_parent_audit = self.project.audits.last
-    last_parent_audit.update(request_uuid: last_audit.request_uuid)
+    if saved_changes?
+      last_audit = self.audits.last
+      new_comment = last_audit.comment ? last_audit.comment.merge({raised_by_audit: last_audit.id}) : {raised_by_audit: last_audit.id}
+      self.project.update(etag: SecureRandom.hex, audit_comment: new_comment)
+      last_parent_audit = self.project.audits.last
+      last_parent_audit.update(request_uuid: last_audit.request_uuid)
+    end
   end
 end

--- a/app/models/project_permission.rb
+++ b/app/models/project_permission.rb
@@ -2,7 +2,7 @@ class ProjectPermission < ActiveRecord::Base
   include RequestAudited
   default_scope { order('created_at DESC') }
   audited
-  after_save :update_project_etag
+  after_save :update_project_etag, if: :saved_changes?
   after_destroy :update_project_etag
 
   belongs_to :user
@@ -17,12 +17,10 @@ class ProjectPermission < ActiveRecord::Base
   private
 
   def update_project_etag
-    if saved_changes?
-      last_audit = self.audits.last
-      new_comment = last_audit.comment ? last_audit.comment.merge({raised_by_audit: last_audit.id}) : {raised_by_audit: last_audit.id}
-      self.project.update(etag: SecureRandom.hex, audit_comment: new_comment)
-      last_parent_audit = self.project.audits.last
-      last_parent_audit.update(request_uuid: last_audit.request_uuid)
-    end
+    last_audit = self.audits.last
+    new_comment = last_audit.comment ? last_audit.comment.merge({raised_by_audit: last_audit.id}) : {raised_by_audit: last_audit.id}
+    self.project.update(etag: SecureRandom.hex, audit_comment: new_comment)
+    last_parent_audit = self.project.audits.last
+    last_parent_audit.update(request_uuid: last_audit.request_uuid)
   end
 end

--- a/spec/models/affiliation_spec.rb
+++ b/spec/models/affiliation_spec.rb
@@ -39,4 +39,32 @@ RSpec.describe Affiliation, type: :model do
       should validate_presence_of(:project_role_id)
     end
   end
+
+  describe '#update_project_etag' do
+    let(:created_object) { FactoryBot.build(:affiliation) }
+
+    let(:user) { FactoryBot.create(:user) }
+    let(:object_unchanged) {
+      FactoryBot.create(:affiliation, user: user)
+    }
+    let(:new_project_role) { FactoryBot.create(:project_role) }
+    let(:object_to_update) {
+      FactoryBot.create(:affiliation, user: user)
+    }
+    let(:object_to_destroy) {
+      FactoryBot.create(:affiliation)
+    }
+
+    before do
+      unchanged_project_role = object_unchanged.project_role
+      object_unchanged.project_role = unchanged_project_role
+      object_to_update.project_role = new_project_role
+    end
+
+    it_behaves_like 'a parent project etag update',
+      :created_object,
+      :object_unchanged,
+      :object_to_update,
+      :object_to_destroy
+  end
 end

--- a/spec/models/affiliation_spec.rb
+++ b/spec/models/affiliation_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 
 RSpec.describe Affiliation, type: :model do
   subject { FactoryBot.build(:affiliation) }
+  let(:new_project_role) { FactoryBot.create(:project_role) }
+  let(:change_subject) {
+    subject.project_role = new_project_role
+    true
+  }
 
   it_behaves_like 'an audited model'
   describe 'associations' do
@@ -39,4 +44,6 @@ RSpec.describe Affiliation, type: :model do
       should validate_presence_of(:project_role_id)
     end
   end
+
+  it_behaves_like 'a ProjectUpdater'
 end

--- a/spec/models/project_permission_spec.rb
+++ b/spec/models/project_permission_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ProjectPermission, type: :model do
   subject {FactoryBot.build(:project_permission)}
+  let(:project) { subject.project }
 
   it_behaves_like 'an audited model'
 
@@ -46,5 +47,87 @@ RSpec.describe ProjectPermission, type: :model do
       is_expected.to callback(:update_project_etag ).after(:save)
       is_expected.to callback(:update_project_etag ).after(:destroy)
     }
+
+    context 'after create' do
+      subject { FactoryBot.build(:project_permission, :project_admin) }
+      let!(:original_project_etag) { project.etag }
+
+      it {
+        expect(subject.save).to be_truthy
+        project.reload
+        subject.reload
+        last_project_audit = project.audits.last
+        last_subject_audit = subject.audits.last
+        expect(project.etag).not_to eq(original_project_etag)
+
+        expected_comment = last_subject_audit.comment ? last_subject_audit.comment.merge({raised_by_audit: last_subject_audit.id}) : {raised_by_audit: last_subject_audit.id}
+        expect(last_project_audit.comment.symbolize_keys).to eq(expected_comment)
+
+        expect(last_project_audit.request_uuid).to eq(last_subject_audit.request_uuid)
+      }
+    end
+
+    context 'after update' do
+      let(:user) { FactoryBot.create(:user) }
+      subject {
+        FactoryBot.create(:project_permission, :project_admin, user: user)
+      }
+
+      context 'without auth_role change' do
+        let!(:auth_role) { subject.auth_role }
+        let!(:original_project_etag) { project.etag }
+        let!(:original_project_audit) { project.audits.last }
+        let!(:original_subject_last_audit) { subject.audits.last }
+        it {
+          subject.auth_role = auth_role
+          expect(subject.save).to be_truthy
+          project.reload
+          expect(project.etag).to eq(original_project_etag)
+          last_project_audit = project.audits.last
+          expect(last_project_audit.comment).to eq(original_project_audit.comment)
+          expect(last_project_audit.request_uuid).to eq(original_project_audit.request_uuid)
+        }
+      end
+
+      context 'with auth_role change' do
+        let(:auth_role) { FactoryBot.create(:auth_role, :project_viewer) }
+        let!(:original_project_etag) { project.etag }
+        it {
+          subject.auth_role = auth_role
+          expect(subject.save).to be_truthy
+          project.reload
+          subject.reload
+          last_project_audit = project.audits.last
+          last_subject_audit = subject.audits.last
+          expect(project.etag).not_to eq(original_project_etag)
+
+          expected_comment = last_subject_audit.comment ? last_subject_audit.comment.merge({raised_by_audit: last_subject_audit.id}) : {raised_by_audit: last_subject_audit.id}
+          expect(last_project_audit.comment.symbolize_keys).to eq(expected_comment)
+
+          expect(last_project_audit.request_uuid).to eq(last_subject_audit.request_uuid)
+        }
+      end
+    end
+
+    context 'destroy' do
+      subject {
+        FactoryBot.create(:project_permission, :project_admin)
+      }
+      let!(:original_project_etag) { project.etag }
+      it {
+        expect(subject.audits.count).to be > 0
+        expect(subject.destroy).to be_truthy
+        project.reload
+        last_project_audit = project.audits.last
+        last_subject_audit = subject.audits.last
+        expect(project.etag).not_to eq(original_project_etag)
+
+        expected_comment = last_subject_audit.comment ? last_subject_audit.comment.merge({raised_by_audit: last_subject_audit.id}) : {raised_by_audit: last_subject_audit.id}
+        expect(last_project_audit.comment.symbolize_keys).to eq(expected_comment)
+
+        expect(last_project_audit.request_uuid).to eq(last_subject_audit.request_uuid)
+      }
+    end
+
   end
 end

--- a/spec/models/project_permission_spec.rb
+++ b/spec/models/project_permission_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe ProjectPermission, type: :model do
   subject {FactoryBot.build(:project_permission)}
-  let(:project) { subject.project }
 
   it_behaves_like 'an audited model'
 
@@ -43,90 +42,34 @@ RSpec.describe ProjectPermission, type: :model do
   end
 
   describe '#update_project_etag' do
-    it {
-      is_expected.to callback(:update_project_etag).after(:save)
-      is_expected.to callback(:update_project_etag).after(:destroy)
+    let(:created_object) {
+      FactoryBot.build(:project_permission, :project_admin)
     }
 
-    context 'after create' do
-      subject { FactoryBot.build(:project_permission, :project_admin) }
-      let!(:original_project_etag) { project.etag }
+    let(:user) { FactoryBot.create(:user) }
+    let(:object_unchanged) {
+      FactoryBot.create(:project_permission, :project_admin, user: user)
+    }
+    let(:new_auth_role) {
+      FactoryBot.create(:auth_role, :project_viewer)
+    }
+    let(:object_to_update) {
+      FactoryBot.create(:project_permission, :project_admin, user: user)
+    }
+    let(:object_to_destroy) {
+      FactoryBot.create(:project_permission, :project_admin)
+    }
 
-      it {
-        expect(subject.save).to be_truthy
-        project.reload
-        subject.reload
-        last_project_audit = project.audits.last
-        last_subject_audit = subject.audits.last
-        expect(project.etag).not_to eq(original_project_etag)
-
-        expected_comment = last_subject_audit.comment ? last_subject_audit.comment.merge({raised_by_audit: last_subject_audit.id}) : {raised_by_audit: last_subject_audit.id}
-        expect(last_project_audit.comment.symbolize_keys).to eq(expected_comment)
-
-        expect(last_project_audit.request_uuid).to eq(last_subject_audit.request_uuid)
-      }
+    before do
+      unchanged_auth_role = object_unchanged.auth_role
+      object_unchanged.auth_role = unchanged_auth_role
+      object_to_update.auth_role = new_auth_role
     end
 
-    context 'after update' do
-      let(:user) { FactoryBot.create(:user) }
-      subject {
-        FactoryBot.create(:project_permission, :project_admin, user: user)
-      }
-
-      context 'without auth_role change' do
-        let!(:auth_role) { subject.auth_role }
-        let!(:original_project_etag) { project.etag }
-        let!(:original_project_audit) { project.audits.last }
-        let!(:original_subject_last_audit) { subject.audits.last }
-        it {
-          subject.auth_role = auth_role
-          expect(subject.save).to be_truthy
-          project.reload
-          expect(project.etag).to eq(original_project_etag)
-          last_project_audit = project.audits.last
-          expect(last_project_audit.comment).to eq(original_project_audit.comment)
-          expect(last_project_audit.request_uuid).to eq(original_project_audit.request_uuid)
-        }
-      end
-
-      context 'with auth_role change' do
-        let(:auth_role) { FactoryBot.create(:auth_role, :project_viewer) }
-        let!(:original_project_etag) { project.etag }
-        it {
-          subject.auth_role = auth_role
-          expect(subject.save).to be_truthy
-          project.reload
-          subject.reload
-          last_project_audit = project.audits.last
-          last_subject_audit = subject.audits.last
-          expect(project.etag).not_to eq(original_project_etag)
-
-          expected_comment = last_subject_audit.comment ? last_subject_audit.comment.merge({raised_by_audit: last_subject_audit.id}) : {raised_by_audit: last_subject_audit.id}
-          expect(last_project_audit.comment.symbolize_keys).to eq(expected_comment)
-
-          expect(last_project_audit.request_uuid).to eq(last_subject_audit.request_uuid)
-        }
-      end
-    end
-
-    context 'destroy' do
-      subject {
-        FactoryBot.create(:project_permission, :project_admin)
-      }
-      let!(:original_project_etag) { project.etag }
-      it {
-        expect(subject.audits.count).to be > 0
-        expect(subject.destroy).to be_truthy
-        project.reload
-        last_project_audit = project.audits.last
-        last_subject_audit = subject.audits.last
-        expect(project.etag).not_to eq(original_project_etag)
-
-        expected_comment = last_subject_audit.comment ? last_subject_audit.comment.merge({raised_by_audit: last_subject_audit.id}) : {raised_by_audit: last_subject_audit.id}
-        expect(last_project_audit.comment.symbolize_keys).to eq(expected_comment)
-
-        expect(last_project_audit.request_uuid).to eq(last_subject_audit.request_uuid)
-      }
-    end
+    it_behaves_like 'a parent project etag update',
+      :created_object,
+      :object_unchanged,
+      :object_to_update,
+      :object_to_destroy
   end
 end

--- a/spec/models/project_permission_spec.rb
+++ b/spec/models/project_permission_spec.rb
@@ -1,8 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe ProjectPermission, type: :model do
-  subject {FactoryBot.build(:project_permission)}
-  let(:project) { subject.project }
+  subject {
+    FactoryBot.build(:project_permission, :project_admin)
+  }
+  let(:new_auth_role) {
+    FactoryBot.create(:auth_role, :project_viewer)
+  }
+  let(:change_subject) {
+    subject.auth_role = new_auth_role
+    true
+  }
 
   it_behaves_like 'an audited model'
 
@@ -42,91 +50,5 @@ RSpec.describe ProjectPermission, type: :model do
     end
   end
 
-  describe '#update_project_etag' do
-    it {
-      is_expected.to callback(:update_project_etag).after(:save)
-      is_expected.to callback(:update_project_etag).after(:destroy)
-    }
-
-    context 'after create' do
-      subject { FactoryBot.build(:project_permission, :project_admin) }
-      let!(:original_project_etag) { project.etag }
-
-      it {
-        expect(subject.save).to be_truthy
-        project.reload
-        subject.reload
-        last_project_audit = project.audits.last
-        last_subject_audit = subject.audits.last
-        expect(project.etag).not_to eq(original_project_etag)
-
-        expected_comment = last_subject_audit.comment ? last_subject_audit.comment.merge({raised_by_audit: last_subject_audit.id}) : {raised_by_audit: last_subject_audit.id}
-        expect(last_project_audit.comment.symbolize_keys).to eq(expected_comment)
-
-        expect(last_project_audit.request_uuid).to eq(last_subject_audit.request_uuid)
-      }
-    end
-
-    context 'after update' do
-      let(:user) { FactoryBot.create(:user) }
-      subject {
-        FactoryBot.create(:project_permission, :project_admin, user: user)
-      }
-
-      context 'without auth_role change' do
-        let!(:auth_role) { subject.auth_role }
-        let!(:original_project_etag) { project.etag }
-        let!(:original_project_audit) { project.audits.last }
-        let!(:original_subject_last_audit) { subject.audits.last }
-        it {
-          subject.auth_role = auth_role
-          expect(subject.save).to be_truthy
-          project.reload
-          expect(project.etag).to eq(original_project_etag)
-          last_project_audit = project.audits.last
-          expect(last_project_audit.comment).to eq(original_project_audit.comment)
-          expect(last_project_audit.request_uuid).to eq(original_project_audit.request_uuid)
-        }
-      end
-
-      context 'with auth_role change' do
-        let(:auth_role) { FactoryBot.create(:auth_role, :project_viewer) }
-        let!(:original_project_etag) { project.etag }
-        it {
-          subject.auth_role = auth_role
-          expect(subject.save).to be_truthy
-          project.reload
-          subject.reload
-          last_project_audit = project.audits.last
-          last_subject_audit = subject.audits.last
-          expect(project.etag).not_to eq(original_project_etag)
-
-          expected_comment = last_subject_audit.comment ? last_subject_audit.comment.merge({raised_by_audit: last_subject_audit.id}) : {raised_by_audit: last_subject_audit.id}
-          expect(last_project_audit.comment.symbolize_keys).to eq(expected_comment)
-
-          expect(last_project_audit.request_uuid).to eq(last_subject_audit.request_uuid)
-        }
-      end
-    end
-
-    context 'destroy' do
-      subject {
-        FactoryBot.create(:project_permission, :project_admin)
-      }
-      let!(:original_project_etag) { project.etag }
-      it {
-        expect(subject.audits.count).to be > 0
-        expect(subject.destroy).to be_truthy
-        project.reload
-        last_project_audit = project.audits.last
-        last_subject_audit = subject.audits.last
-        expect(project.etag).not_to eq(original_project_etag)
-
-        expected_comment = last_subject_audit.comment ? last_subject_audit.comment.merge({raised_by_audit: last_subject_audit.id}) : {raised_by_audit: last_subject_audit.id}
-        expect(last_project_audit.comment.symbolize_keys).to eq(expected_comment)
-
-        expect(last_project_audit.request_uuid).to eq(last_subject_audit.request_uuid)
-      }
-    end
-  end
+  it_behaves_like 'a ProjectUpdater'
 end

--- a/spec/models/project_permission_spec.rb
+++ b/spec/models/project_permission_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe ProjectPermission, type: :model do
 
   describe '#update_project_etag' do
     it {
-      is_expected.to callback(:update_project_etag ).after(:save)
-      is_expected.to callback(:update_project_etag ).after(:destroy)
+      is_expected.to callback(:update_project_etag).after(:save)
+      is_expected.to callback(:update_project_etag).after(:destroy)
     }
 
     context 'after create' do
@@ -128,6 +128,5 @@ RSpec.describe ProjectPermission, type: :model do
         expect(last_project_audit.request_uuid).to eq(last_subject_audit.request_uuid)
       }
     end
-
   end
 end

--- a/spec/models/project_permission_spec.rb
+++ b/spec/models/project_permission_spec.rb
@@ -40,4 +40,11 @@ RSpec.describe ProjectPermission, type: :model do
       should validate_presence_of(:auth_role_id)
     end
   end
+
+  describe '#update_project_etag' do
+    it {
+      is_expected.to callback(:update_project_etag ).after(:save)
+      is_expected.to callback(:update_project_etag ).after(:destroy)
+    }
+  end
 end

--- a/spec/support/concerns/project_updater_shared_examples.rb
+++ b/spec/support/concerns/project_updater_shared_examples.rb
@@ -1,0 +1,71 @@
+shared_examples 'a ProjectUpdater' do
+  let(:project) { subject.project }
+  let(:create_subject) {
+    subject.save
+    subject.reload
+  }
+
+  it {
+    is_expected.to respond_to(:update_project_etag)
+    is_expected.to callback(:update_project_etag).after(:save)
+    is_expected.to callback(:update_project_etag).after(:destroy)
+  }
+
+  describe '#update_project_etag' do
+    let!(:original_project_etag) { project.etag }
+    it {
+      expect(create_subject).to be_truthy
+      expect(change_subject).to be_truthy
+      subject.update_project_etag
+      project.reload
+      subject.reload
+      last_project_audit = project.audits.last
+      last_subject_audit = subject.audits.last
+      expect(project.etag).not_to eq(original_project_etag)
+
+      expected_comment = last_subject_audit.comment ? last_subject_audit.comment.merge({raised_by_audit: last_subject_audit.id}) : {raised_by_audit: last_subject_audit.id}
+      expect(last_project_audit.comment.symbolize_keys).to eq(expected_comment)
+
+      expect(last_project_audit.request_uuid).to eq(last_subject_audit.request_uuid)
+    }
+  end
+
+  context 'after create' do
+    it {
+      is_expected.not_to be_persisted
+      is_expected.to receive(:update_project_etag)
+      expect(subject.save).to be_truthy
+    }
+  end
+
+  context 'after update' do
+    before do
+      expect(create_subject).to be_truthy
+    end
+
+    context 'without change' do
+      it {
+        is_expected.not_to receive(:update_project_etag)
+        expect(subject.saved_changes?).to be_falsey
+        expect(subject.save).to be_truthy
+      }
+    end
+
+    context 'with change' do
+      it {
+        is_expected.to receive(:update_project_etag)
+        expect(change_subject).to be_truthy
+        expect(subject.changed?).to be_truthy
+        expect(subject.save).to be_truthy
+      }
+    end
+  end
+
+  context 'destroy' do
+    it {
+      expect(create_subject).to be_truthy
+      is_expected.to receive(:update_project_etag)
+      expect(subject.destroy).to be_truthy
+    }
+  end
+end

--- a/spec/support/concerns/project_updater_shared_examples.rb
+++ b/spec/support/concerns/project_updater_shared_examples.rb
@@ -28,7 +28,7 @@ shared_examples 'a ProjectUpdater' do
       expect(project.etag).not_to eq(original_project_etag)
     }
 
-    describe 'with audit comment' do
+    context 'with audit comment' do
       let(:last_project_audit) { project.audits.last }
       let(:last_subject_audit) { subject.audits.last }
 

--- a/spec/support/concerns/updates_project_etag.rb
+++ b/spec/support/concerns/updates_project_etag.rb
@@ -1,0 +1,98 @@
+shared_examples 'a parent project etag update' do |
+    newly_created_object_sym,
+    unchanged_object_sym,
+    updated_object_sym,
+    destroyed_object_sym
+  |
+  let(:newly_created_object) { send(newly_created_object_sym) }
+  let(:unchanged_object) { send(unchanged_object_sym) }
+  let(:updated_object) { send(updated_object_sym) }
+  let(:destroyed_object) { send(destroyed_object_sym) }
+  let(:project) { subject.project }
+
+  it {
+    is_expected.to callback(:update_project_etag).after(:save)
+    is_expected.to callback(:update_project_etag).after(:destroy)
+  }
+
+  context 'after create' do
+    subject { newly_created_object }
+    let!(:original_project_etag) { project.etag }
+
+    it {
+      expect(subject.save).to be_truthy
+      project.reload
+      subject.reload
+      last_project_audit = project.audits.last
+      last_subject_audit = subject.audits.last
+      expect(project.etag).not_to eq(original_project_etag)
+
+      expected_comment = last_subject_audit.comment ? last_subject_audit.comment.merge({raised_by_audit: last_subject_audit.id}) : {raised_by_audit: last_subject_audit.id}
+      expect(last_project_audit.comment.symbolize_keys).to eq(expected_comment)
+
+      expect(last_project_audit.request_uuid).to eq(last_subject_audit.request_uuid)
+    }
+  end
+
+  context 'after update' do
+    let(:user) { FactoryBot.create(:user) }
+
+    context 'without change' do
+      subject {
+        unchanged_object
+      }
+      let!(:original_project_etag) { project.etag }
+      let!(:original_project_audit) { project.audits.last }
+      let!(:original_subject_last_audit) { subject.audits.last }
+      it {
+        expect(subject.save).to be_truthy
+        project.reload
+        expect(project.etag).to eq(original_project_etag)
+        last_project_audit = project.audits.last
+        expect(last_project_audit.comment).to eq(original_project_audit.comment)
+        expect(last_project_audit.request_uuid).to eq(original_project_audit.request_uuid)
+      }
+    end
+
+    context 'with change' do
+      subject {
+        updated_object
+      }
+      let!(:original_project_etag) { project.etag }
+
+      it {
+        expect(subject.save).to be_truthy
+        project.reload
+        subject.reload
+        last_project_audit = project.audits.last
+        last_subject_audit = subject.audits.last
+        expect(project.etag).not_to eq(original_project_etag)
+
+        expected_comment = last_subject_audit.comment ? last_subject_audit.comment.merge({raised_by_audit: last_subject_audit.id}) : {raised_by_audit: last_subject_audit.id}
+        expect(last_project_audit.comment.symbolize_keys).to eq(expected_comment)
+
+        expect(last_project_audit.request_uuid).to eq(last_subject_audit.request_uuid)
+      }
+    end
+  end
+
+  context 'destroy' do
+    subject {
+      destroyed_object
+    }
+    let!(:original_project_etag) { project.etag }
+    it {
+      expect(subject.audits.count).to be > 0
+      expect(subject.destroy).to be_truthy
+      project.reload
+      last_project_audit = project.audits.last
+      last_subject_audit = subject.audits.last
+      expect(project.etag).not_to eq(original_project_etag)
+
+      expected_comment = last_subject_audit.comment ? last_subject_audit.comment.merge({raised_by_audit: last_subject_audit.id}) : {raised_by_audit: last_subject_audit.id}
+      expect(last_project_audit.comment.symbolize_keys).to eq(expected_comment)
+
+      expect(last_project_audit.request_uuid).to eq(last_subject_audit.request_uuid)
+    }
+  end
+end


### PR DESCRIPTION
prevent project_permissions updates without any changes from updating the project etag
