### PR TITLE
DDS-1160 refactor job transaction orphan cleanup

### DIFF
--- a/app/models/job_transaction.rb
+++ b/app/models/job_transaction.rb
@@ -8,8 +8,12 @@ class JobTransaction < ActiveRecord::Base
   scope :orphans, ->(limit: nil) { where(request_id: orphan_request_ids(limit: limit)) }
   scope :logical_orphans, -> { where(arel_table[:request_id].in(logical_orphan_request_ids)) }
 
+  def self.initial_states
+    ['updated', 'created', 'trashbin_migration']
+  end
+
   def self.logical_orphan_request_ids
-    requests_without_orphans = select(:request_id).where.not(state: ['created', 'updated'])
+    requests_without_orphans = select(:request_id).where.not(state: initial_states)
     arel_table.project(arel_table[:request_id]).except(requests_without_orphans)
   end
 

--- a/lib/tasks/job_transaction.rake
+++ b/lib/tasks/job_transaction.rake
@@ -19,7 +19,7 @@ namespace :job_transaction do
 
     desc 'Removes orphan JobTransactions older than a month'
     task orphans: :environment do
-      batch_size = ENV['BATCH_SIZE']&.to_i || 1000
+      batch_size = ENV['BATCH_SIZE']&.to_i || 50000
       if oldest = JobTransaction.oldest_orphan_created_at
         months_ago = ((Time.now - oldest) / 1.month).floor
         if months_ago > 0

--- a/lib/tasks/job_transaction.rake
+++ b/lib/tasks/job_transaction.rake
@@ -19,14 +19,20 @@ namespace :job_transaction do
 
     desc 'Removes orphan JobTransactions older than a month'
     task orphans: :environment do
-      batch_size = 1000
+      batch_size = ENV['BATCH_SIZE']&.to_i || 1000
       if oldest = JobTransaction.oldest_orphan_created_at
         months_ago = ((Time.now - oldest) / 1.month).floor
         if months_ago > 0
           months_ago.downto(1).each do |m|
-            del_num = JobTransaction.delete_all_orphans(created_before: Time.now - m.months, limit: batch_size)
+            total_del_num = 0
+            loop do
+              del_num = JobTransaction.delete_all_orphans(created_before: Time.now - m.months, limit: batch_size)
+              print '-'
+              total_del_num += del_num
+              break if del_num < batch_size
+            end
             puts '-'
-            puts "Deleted #{del_num} orphan JobTransactions from #{m} #{'month'.pluralize(m)} ago."
+            puts "Deleted #{total_del_num} orphan JobTransactions from #{m} #{'month'.pluralize(m)} ago."
           end
         else
           puts "No orphan JobTransactions older than 1 month found."

--- a/lib/tasks/job_transaction.rake
+++ b/lib/tasks/job_transaction.rake
@@ -19,11 +19,13 @@ namespace :job_transaction do
 
     desc 'Removes orphan JobTransactions older than a month'
     task orphans: :environment do
+      batch_size = 1000
       if oldest = JobTransaction.oldest_orphan_created_at
         months_ago = ((Time.now - oldest) / 1.month).floor
         if months_ago > 0
           months_ago.downto(1).each do |m|
-            del_num = JobTransaction.delete_all_orphans(created_before: Time.now - m.months)
+            del_num = JobTransaction.delete_all_orphans(created_before: Time.now - m.months, limit: batch_size)
+            puts '-'
             puts "Deleted #{del_num} orphan JobTransactions from #{m} #{'month'.pluralize(m)} ago."
           end
         else

--- a/spec/lib/tasks/job_transaction_rake_spec.rb
+++ b/spec/lib/tasks/job_transaction_rake_spec.rb
@@ -44,7 +44,7 @@ describe 'job_transaction:clean_up:orphans' do
   include ActiveSupport::Testing::TimeHelpers
   include_context "rake"
 
-  let(:default_batch_size) { 1000 }
+  let(:default_batch_size) { 50000 }
   let(:oldest_orphan_created_at) { nil }
   around(:each) do |example|
     travel_to(Time.now) do #freeze_time
@@ -142,7 +142,7 @@ describe 'job_transaction:clean_up:all' do
   include ActiveSupport::Testing::TimeHelpers
   include_context "rake"
 
-  let(:default_batch_size) { 1000 }
+  let(:default_batch_size) { 50000 }
   let(:a_month_ago) { Time.now - 1.month }
   let(:just_over_a_month_ago) { Time.now - 1.month - 1.day }
   around(:each) do |example|

--- a/spec/models/job_transaction_spec.rb
+++ b/spec/models/job_transaction_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe JobTransaction, type: :model do
   describe '.oldest_completed_at' do
     let(:oldest_completed_at) { described_class.oldest_completed_at }
     it { expect(described_class).to respond_to(:oldest_completed_at) }
-    it { expect(described_class).to respond_to(:oldest_completed_at) }
     it { expect(oldest_completed_at).to be_nil }
 
     context 'with multiple completed' do

--- a/spec/models/job_transaction_spec.rb
+++ b/spec/models/job_transaction_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe JobTransaction, type: :model do
   describe '.oldest_completed_at' do
     let(:oldest_completed_at) { described_class.oldest_completed_at }
     it { expect(described_class).to respond_to(:oldest_completed_at) }
+    it { expect(described_class).to respond_to(:oldest_completed_at) }
     it { expect(oldest_completed_at).to be_nil }
 
     context 'with multiple completed' do
@@ -170,6 +171,7 @@ RSpec.describe JobTransaction, type: :model do
     let(:delete_all_orphans) { described_class.delete_all_orphans }
     it { expect(described_class).to respond_to(:delete_all_orphans).with(0).arguments }
     it { expect(described_class).to respond_to(:delete_all_orphans).with_keywords(:created_before) }
+    it { expect(described_class).to respond_to(:delete_all_orphans).with_keywords(:limit) }
     it { expect(delete_all_orphans).to eq 0 }
 
     context 'with multiple orphans' do
@@ -183,6 +185,11 @@ RSpec.describe JobTransaction, type: :model do
       context 'created_before last orphan' do
         let(:delete_all_orphans) { described_class.delete_all_orphans(created_before: orphan_jobs.last.created_at) }
         it { expect{delete_all_orphans}.to change{JobTransaction.count}.by(-2) }
+      end
+
+      context 'limit to 1' do
+        let(:delete_all_orphans) { described_class.delete_all_orphans(limit: 1) }
+        it { expect{delete_all_orphans}.to change{JobTransaction.count}.by(-1) }
       end
     end
 


### PR DESCRIPTION
- Refactored JobTransaction code to build more scalable SQL
- BATCH_SIZE env for job_transaction:clean_up:orphans (default: 50000)