### PR TITLE
DDS-1170-auth_service_serializer_enhancements

### DIFF
--- a/app/serializers/authentication_service_serializer.rb
+++ b/app/serializers/authentication_service_serializer.rb
@@ -1,3 +1,10 @@
 class AuthenticationServiceSerializer < ActiveModel::Serializer
-  attributes :id, :service_id, :name, :is_deprecated, :is_default, :login_initiation_url
+  attributes :id,
+             :service_id,
+             :name,
+             :is_deprecated,
+             :is_default,
+             :login_initiation_url,
+             :base_uri,
+             :login_response_type
 end

--- a/spec/support/authentication_service_shared_examples.rb
+++ b/spec/support/authentication_service_shared_examples.rb
@@ -479,7 +479,9 @@ shared_examples 'an authentication_service_serializer serializable resource' do
     'name' => resource.name,
     'login_initiation_url' => resource.login_initiation_url,
     'is_deprecated' => resource.is_deprecated,
-    'is_default' => resource.is_default
+    'is_default' => resource.is_default,
+    'base_uri' => resource.base_uri,
+    'login_response_type' => resource.login_response_type
   }}
 
   it_behaves_like 'a json serializer' do


### PR DESCRIPTION
added base_uri and login_response_type to the serializer
did not add client_id as this may be sensitive