### PR TITLE
DDS-1171 job to initialize chunked upload

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,6 +2,7 @@ web: bundle exec puma -C config/puma.rb
 all_workers: bundle exec rake workers:all:run
 message_log_worker: bundle exec rake workers:message_logger:run
 project_storage_init_job: bundle exec rake workers:initialize_project_storage:run
+upload_storage_init_job: bundle exec rake workers:initialize_upload_storage:run
 child_deletion_job: bundle exec rake workers:delete_children:run
 child_purgation_job: bundle exec rake workers:purge_children:run
 child_restoration_job: bundle exec rake workers:restore_children:run

--- a/app/api/dds/v1/uploads_api.rb
+++ b/app/api/dds/v1/uploads_api.rb
@@ -123,7 +123,7 @@ module DDS
               fingerprint_value: chunk_params[:hash][:value],
               fingerprint_algorithm: chunk_params[:hash][:algorithm],
             }
-            if chunk.save
+            if chunk.url && chunk.save
               chunk
             else
               validation_error!(chunk)

--- a/app/api/dds/v1/uploads_api.rb
+++ b/app/api/dds/v1/uploads_api.rb
@@ -123,7 +123,8 @@ module DDS
               fingerprint_value: chunk_params[:hash][:value],
               fingerprint_algorithm: chunk_params[:hash][:algorithm],
             }
-            if chunk.url && chunk.save
+            chunk.check_upload_readiness!
+            if chunk.save
               chunk
             else
               validation_error!(chunk)

--- a/app/api/dds/v1/uploads_api.rb
+++ b/app/api/dds/v1/uploads_api.rb
@@ -112,6 +112,7 @@ module DDS
             authenticate!
             chunk_params = declared(params, include_missing: false)
             upload = Upload.find(params[:id])
+            upload.check_readiness!
             if chunk = Chunk.find_by(upload: upload, number: chunk_params[:number])
               authorize chunk, :update?
             else
@@ -123,7 +124,6 @@ module DDS
               fingerprint_value: chunk_params[:hash][:value],
               fingerprint_algorithm: chunk_params[:hash][:algorithm],
             }
-            chunk.check_upload_readiness!
             if chunk.save
               chunk
             else

--- a/app/jobs/upload_storage_provider_initialization_job.rb
+++ b/app/jobs/upload_storage_provider_initialization_job.rb
@@ -1,0 +1,9 @@
+class UploadStorageProviderInitializationJob < ApplicationJob
+  queue_as :upload_storage_provider_initialization
+
+  def perform(job_transaction:, storage_provider:, upload:)
+    self.class.start_job job_transaction
+    storage_provider.initialize_chunked_upload(upload)
+    self.class.complete_job job_transaction
+  end
+end

--- a/app/models/chunk.rb
+++ b/app/models/chunk.rb
@@ -43,6 +43,10 @@ class Chunk < ActiveRecord::Base
     [storage_container, object_path].join('/')
   end
 
+  def upload_ready?
+    storage_provider.chunk_upload_ready?(self)
+  end
+
   def url
     begin
       storage_provider.chunk_upload_url(self)

--- a/app/models/chunk.rb
+++ b/app/models/chunk.rb
@@ -43,14 +43,6 @@ class Chunk < ActiveRecord::Base
     [storage_container, object_path].join('/')
   end
 
-  def check_upload_readiness!
-    upload_ready? or raise ConsistencyException, 'Upload is not ready'
-  end
-
-  def upload_ready?
-    storage_provider.chunk_upload_ready?(self.upload)
-  end
-
   def url
     begin
       storage_provider.chunk_upload_url(self)

--- a/app/models/chunk.rb
+++ b/app/models/chunk.rb
@@ -44,7 +44,15 @@ class Chunk < ActiveRecord::Base
   end
 
   def url
-    storage_provider.chunk_upload_url(self)
+    begin
+      storage_provider.chunk_upload_url(self)
+    rescue StorageProviderException => e
+      if e.message == 'Upload is not ready'
+        raise ConsistencyException, e.message if e.message == 'Upload is not ready'
+      else
+        raise e
+      end
+    end
   end
 
   def purge_storage

--- a/app/models/chunk.rb
+++ b/app/models/chunk.rb
@@ -48,7 +48,7 @@ class Chunk < ActiveRecord::Base
   end
 
   def upload_ready?
-    storage_provider.chunk_upload_ready?(self)
+    storage_provider.chunk_upload_ready?(self.upload)
   end
 
   def url

--- a/app/models/chunk.rb
+++ b/app/models/chunk.rb
@@ -43,6 +43,10 @@ class Chunk < ActiveRecord::Base
     [storage_container, object_path].join('/')
   end
 
+  def check_upload_readiness!
+    upload_ready? or raise ConsistencyException, 'Upload is not ready'
+  end
+
   def upload_ready?
     storage_provider.chunk_upload_ready?(self)
   end

--- a/app/models/s3_storage_provider.rb
+++ b/app/models/s3_storage_provider.rb
@@ -68,8 +68,8 @@ class S3StorageProvider < StorageProvider
     head_object(upload.storage_container, upload.id)
   end
 
-  def chunk_upload_ready?(chunk)
-    !!chunk.upload.multipart_upload_id
+  def chunk_upload_ready?(upload)
+    !!upload.multipart_upload_id
   end
 
   def chunk_upload_url(chunk)

--- a/app/models/s3_storage_provider.rb
+++ b/app/models/s3_storage_provider.rb
@@ -68,6 +68,9 @@ class S3StorageProvider < StorageProvider
     head_object(upload.storage_container, upload.id)
   end
 
+  def chunk_upload_ready?(chunk)
+  end
+
   def chunk_upload_url(chunk)
     begin
       presigned_url(

--- a/app/models/s3_storage_provider.rb
+++ b/app/models/s3_storage_provider.rb
@@ -69,6 +69,7 @@ class S3StorageProvider < StorageProvider
   end
 
   def chunk_upload_ready?(chunk)
+    !!chunk.upload.multipart_upload_id
   end
 
   def chunk_upload_url(chunk)

--- a/app/models/s3_storage_provider.rb
+++ b/app/models/s3_storage_provider.rb
@@ -69,14 +69,18 @@ class S3StorageProvider < StorageProvider
   end
 
   def chunk_upload_url(chunk)
-    presigned_url(
-      :upload_part,
-      bucket_name: chunk.upload.storage_container,
-      object_key: chunk.upload.id,
-      upload_id: chunk.upload.multipart_upload_id,
-      part_number: chunk.number,
-      content_length: chunk.size
-    )
+    begin
+      presigned_url(
+        :upload_part,
+        bucket_name: chunk.upload.storage_container,
+        object_key: chunk.upload.id,
+        upload_id: chunk.upload.multipart_upload_id,
+        part_number: chunk.number,
+        content_length: chunk.size
+      )
+    rescue ArgumentError
+      raise StorageProviderException, 'Upload is not ready'
+    end
   end
 
   def download_url(upload, filename=nil)

--- a/app/models/storage_provider.rb
+++ b/app/models/storage_provider.rb
@@ -46,7 +46,7 @@ class StorageProvider < ActiveRecord::Base
     raise NotImplementedError.new("You must implement initialize_chunked_upload.")
   end
 
-  def chunk_upload_ready?(chunk)
+  def chunk_upload_ready?(upload)
     raise NotImplementedError.new("You must implement chunk_upload_ready?.")
   end
 

--- a/app/models/storage_provider.rb
+++ b/app/models/storage_provider.rb
@@ -46,6 +46,10 @@ class StorageProvider < ActiveRecord::Base
     raise NotImplementedError.new("You must implement initialize_chunked_upload.")
   end
 
+  def chunk_upload_ready?(chunk)
+    raise NotImplementedError.new("You must implement chunk_upload_ready?.")
+  end
+
   def chunk_upload_url(chunk)
     raise NotImplementedError.new("You must implement chunk_upload_url.")
   end

--- a/app/models/swift_storage_provider.rb
+++ b/app/models/swift_storage_provider.rb
@@ -88,7 +88,7 @@ class SwiftStorageProvider < StorageProvider
     return true if get_object_metadata(upload.storage_container, upload.id)
   end
 
-  def chunk_upload_ready?(chunk)
+  def chunk_upload_ready?(upload)
     true
   end
 

--- a/app/models/swift_storage_provider.rb
+++ b/app/models/swift_storage_provider.rb
@@ -89,6 +89,7 @@ class SwiftStorageProvider < StorageProvider
   end
 
   def chunk_upload_ready?(chunk)
+    true
   end
 
   def chunk_upload_url(chunk)

--- a/app/models/swift_storage_provider.rb
+++ b/app/models/swift_storage_provider.rb
@@ -88,6 +88,9 @@ class SwiftStorageProvider < StorageProvider
     return true if get_object_metadata(upload.storage_container, upload.id)
   end
 
+  def chunk_upload_ready?(chunk)
+  end
+
   def chunk_upload_url(chunk)
     build_signed_url(
       'PUT',

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -10,6 +10,7 @@ class Upload < ActiveRecord::Base
   has_many :fingerprints
 
   before_create :set_storage_container
+  after_create :initialize_storage
 
   accepts_nested_attributes_for :fingerprints
 

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -69,6 +69,10 @@ class Upload < ActiveRecord::Base
     )
   end
 
+  def ready_for_chunks?
+    storage_provider.chunk_upload_ready?(self)
+  end
+
   def complete
     transaction do
       self.completed_at = DateTime.now

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -75,6 +75,7 @@ class Upload < ActiveRecord::Base
 
   def check_readiness!
     raise(ConsistencyException, 'Upload is not ready') unless ready_for_chunks?
+    true
   end
 
   def complete

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -60,6 +60,14 @@ class Upload < ActiveRecord::Base
     end
   end
 
+  def initialize_storage
+    UploadStorageProviderInitializationJob.perform_later(
+      job_transaction: UploadStorageProviderInitializationJob.initialize_job(self),
+      storage_provider: storage_provider,
+      upload: self
+    )
+  end
+
   def complete
     transaction do
       self.completed_at = DateTime.now

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -74,7 +74,7 @@ class Upload < ActiveRecord::Base
   end
 
   def check_readiness!
-    ready_for_chunks? or raise ConsistencyException, 'Upload is not ready'
+    ready_for_chunks? || raise(ConsistencyException, 'Upload is not ready')
   end
 
   def complete

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -73,6 +73,10 @@ class Upload < ActiveRecord::Base
     storage_provider.chunk_upload_ready?(self)
   end
 
+  def check_readiness!
+    ready_for_chunks? or raise ConsistencyException, 'Upload is not ready'
+  end
+
   def complete
     transaction do
       self.completed_at = DateTime.now

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -74,7 +74,7 @@ class Upload < ActiveRecord::Base
   end
 
   def check_readiness!
-    ready_for_chunks? || raise(ConsistencyException, 'Upload is not ready')
+    raise(ConsistencyException, 'Upload is not ready') unless ready_for_chunks?
   end
 
   def complete

--- a/app/serializers/upload_serializer.rb
+++ b/app/serializers/upload_serializer.rb
@@ -12,6 +12,7 @@ class UploadSerializer < ActiveModel::Serializer
       initiated_on: object.created_at,
       ready_for_chunks: object.ready_for_chunks?,
       completed_on: object.completed_at,
+      is_consistent: object.is_consistent,
       purged_on: object.purged_on,
       error_on: object.error_at,
       error_message: object.error_message

--- a/app/serializers/upload_serializer.rb
+++ b/app/serializers/upload_serializer.rb
@@ -10,6 +10,7 @@ class UploadSerializer < ActiveModel::Serializer
   def status
     {
       initiated_on: object.created_at,
+      ready_for_chunks: object.ready_for_chunks?,
       completed_on: object.completed_at,
       purged_on: object.purged_on,
       error_on: object.error_at,

--- a/app/services/jobs_runner.rb
+++ b/app/services/jobs_runner.rb
@@ -14,6 +14,7 @@ class JobsRunner
     {
       message_logger: MessageLogWorker,
       initialize_project_storage: ProjectStorageProviderInitializationJob,
+      initialize_upload_storage: UploadStorageProviderInitializationJob,
       delete_children: ChildDeletionJob,
       index_documents: ElasticsearchIndexJob,
       update_project_container_elasticsearch: ProjectContainerElasticsearchUpdateJob,

--- a/lib/tasks/workers.rake
+++ b/lib/tasks/workers.rake
@@ -14,6 +14,13 @@ namespace :workers do
     end
   end
 
+  namespace :initialize_upload_storage do
+    desc 'run a UploadStorageProviderInitializationJob'
+    task run: :environment do
+      JobsRunner.new(UploadStorageProviderInitializationJob).run
+    end
+  end
+
   namespace :update_project_container_elasticsearch do
     desc 'run a ProjectContainerElasticsearchUpdateJob'
     task run: :environment do

--- a/spec/jobs/project_storage_provider_initialization_job_spec.rb
+++ b/spec/jobs/project_storage_provider_initialization_job_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ProjectStorageProviderInitializationJob, type: :job do
-  include_context 'mock all Uploads StorageProvider'
+  include_context 'mocked StorageProvider'
 
   let(:project) { FactoryBot.create(:project, :inconsistent) }
   let(:prefix) { Rails.application.config.active_job.queue_name_prefix }

--- a/spec/jobs/upload_storage_provider_initialization_job_spec.rb
+++ b/spec/jobs/upload_storage_provider_initialization_job_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe UploadStorageProviderInitializationJob, type: :job do
+  include_context 'mocked StorageProvider'
+  include_context 'mocked StorageProvider Interface'
+
+  let(:upload) { FactoryBot.create(:upload, storage_provider: mocked_storage_provider) }
+  let(:prefix) { Rails.application.config.active_job.queue_name_prefix }
+  let(:prefix_delimiter) { Rails.application.config.active_job.queue_name_delimiter }
+  let(:job_transaction) { described_class.initialize_job(upload) }
+
+  it { expect(described_class.should_be_registered_worker?).to be_truthy }
+  it { is_expected.to be_an ApplicationJob }
+  it { expect(prefix).not_to be_nil }
+  it { expect(prefix_delimiter).not_to be_nil }
+  it { expect(described_class.queue_name).to eq("#{prefix}#{prefix_delimiter}upload_storage_provider_initialization") }
+
+  it { expect { described_class.perform_now }.to raise_error(ArgumentError, "missing keywords: job_transaction, storage_provider, upload") }
+
+  context 'perform_now' do
+    include_context 'tracking job', :job_transaction
+    it 'calls storage_provider#initialize_chunked_upload with upload' do
+      expect(mocked_storage_provider).to receive(:initialize_chunked_upload)
+        .with(upload)
+      described_class.perform_now(
+        job_transaction: job_transaction,
+        storage_provider: mocked_storage_provider,
+        upload: upload
+      )
+    end
+  end
+end

--- a/spec/models/chunk_spec.rb
+++ b/spec/models/chunk_spec.rb
@@ -94,17 +94,26 @@ RSpec.describe Chunk, type: :model do
     end
   end
 
+  it { is_expected.to respond_to :url }
   describe '#url' do
     let(:expected_url) { Faker::Internet.url }
+    let(:sp_response) { expected_url }
 
-    it { is_expected.to respond_to :url }
+    before(:example) do
+      expect(mocked_storage_provider).to receive(:chunk_upload_url) { sp_response }
+    end
 
-    it {
-      expect(mocked_storage_provider).to receive(:chunk_upload_url)
-        .and_return(expected_url)
+    it { expect(subject.url).to eq expected_url }
 
-      expect(subject.url).to eq expected_url
-    }
+    context 'Upload not ready exception raised' do
+      let(:sp_response) { raise StorageProviderException, 'Upload is not ready' }
+      it { expect { subject.url }.to raise_error ConsistencyException, 'Upload is not ready' }
+    end
+
+    context 'Unexpected exception raised' do
+      let(:sp_response) { raise StorageProviderException, 'Unexpected' }
+      it { expect { subject.url }.to raise_error StorageProviderException, 'Unexpected' }
+    end
   end
 
   describe '#purge_storage' do

--- a/spec/models/chunk_spec.rb
+++ b/spec/models/chunk_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Chunk, type: :model do
   describe '#upload_ready?' do
     let(:upload_ready) { true }
     before(:example) do
-      expect(mocked_storage_provider).to receive(:chunk_upload_ready?).with(subject) { upload_ready }
+      expect(mocked_storage_provider).to receive(:chunk_upload_ready?).with(upload) { upload_ready }
     end
 
     it { expect(subject.upload_ready?).to eq true }

--- a/spec/models/chunk_spec.rb
+++ b/spec/models/chunk_spec.rb
@@ -94,6 +94,21 @@ RSpec.describe Chunk, type: :model do
     end
   end
 
+  it { is_expected.to respond_to :upload_ready? }
+  describe '#upload_ready?' do
+    let(:upload_ready) { true }
+    before(:example) do
+      expect(mocked_storage_provider).to receive(:chunk_upload_ready?).with(subject) { upload_ready }
+    end
+
+    it { expect(subject.upload_ready?).to eq true }
+
+    context 'when upload is not ready' do
+      let(:upload_ready) { false }
+      it { expect(subject.upload_ready?).to eq false }
+    end
+  end
+
   it { is_expected.to respond_to :url }
   describe '#url' do
     let(:expected_url) { Faker::Internet.url }

--- a/spec/models/chunk_spec.rb
+++ b/spec/models/chunk_spec.rb
@@ -94,35 +94,6 @@ RSpec.describe Chunk, type: :model do
     end
   end
 
-  it { is_expected.to respond_to :check_upload_readiness! }
-  describe '#check_upload_readiness!' do
-    let(:readiness) { true }
-    before(:example) do
-      allow(subject).to receive(:upload_ready?).and_return(readiness)
-    end
-    it { expect(subject.check_upload_readiness!).to be_truthy }
-
-    context 'when not ready' do
-      let(:readiness) { false }
-      it { expect { subject.check_upload_readiness! }.to raise_error ConsistencyException, 'Upload is not ready' }
-    end
-  end
-
-  it { is_expected.to respond_to :upload_ready? }
-  describe '#upload_ready?' do
-    let(:upload_ready) { true }
-    before(:example) do
-      expect(mocked_storage_provider).to receive(:chunk_upload_ready?).with(upload) { upload_ready }
-    end
-
-    it { expect(subject.upload_ready?).to eq true }
-
-    context 'when upload is not ready' do
-      let(:upload_ready) { false }
-      it { expect(subject.upload_ready?).to eq false }
-    end
-  end
-
   it { is_expected.to respond_to :url }
   describe '#url' do
     let(:expected_url) { Faker::Internet.url }

--- a/spec/models/chunk_spec.rb
+++ b/spec/models/chunk_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Chunk, type: :model do
     let(:sp_response) { expected_url }
 
     before(:example) do
-      expect(mocked_storage_provider).to receive(:chunk_upload_url) { sp_response }
+      expect(mocked_storage_provider).to receive(:chunk_upload_url).with(subject) { sp_response }
     end
 
     it { expect(subject.url).to eq expected_url }

--- a/spec/models/chunk_spec.rb
+++ b/spec/models/chunk_spec.rb
@@ -94,6 +94,20 @@ RSpec.describe Chunk, type: :model do
     end
   end
 
+  it { is_expected.to respond_to :check_upload_readiness! }
+  describe '#check_upload_readiness!' do
+    let(:readiness) { true }
+    before(:example) do
+      allow(subject).to receive(:upload_ready?).and_return(readiness)
+    end
+    it { expect(subject.check_upload_readiness!).to be_truthy }
+
+    context 'when not ready' do
+      let(:readiness) { false }
+      it { expect { subject.check_upload_readiness! }.to raise_error ConsistencyException, 'Upload is not ready' }
+    end
+  end
+
   it { is_expected.to respond_to :upload_ready? }
   describe '#upload_ready?' do
     let(:upload_ready) { true }

--- a/spec/models/s3_storage_provider_spec.rb
+++ b/spec/models/s3_storage_provider_spec.rb
@@ -221,9 +221,10 @@ RSpec.describe S3StorageProvider, type: :model do
   end
 
   describe '#chunk_upload_url(chunk)' do
+    let(:upload) { FactoryBot.create(:upload, :skip_validation, multipart_upload_id: multipart_upload_id) }
     let(:bucket_name) { chunk.upload.storage_container }
     let(:object_key) { chunk.upload.id }
-    let(:multipart_upload_id) { chunk.upload.multipart_upload_id }
+    let(:multipart_upload_id) { Faker::Lorem.characters(88) }
     let(:part_number) { chunk.number }
     let(:part_size) { chunk.size }
     let(:expected_url) { Faker::Internet.url }

--- a/spec/models/s3_storage_provider_spec.rb
+++ b/spec/models/s3_storage_provider_spec.rb
@@ -220,14 +220,14 @@ RSpec.describe S3StorageProvider, type: :model do
     end
   end
 
-  describe '#chunk_upload_ready?(chunk)' do
+  describe '#chunk_upload_ready?(upload)' do
     let(:upload) { FactoryBot.create(:upload, :skip_validation, multipart_upload_id: multipart_upload_id) }
     let(:multipart_upload_id) { Faker::Lorem.characters(88) }
-    it { expect(subject.chunk_upload_ready?(chunk)).to eq true }
+    it { expect(subject.chunk_upload_ready?(upload)).to eq true }
 
     context 'when upload.multipart_upload_id is nil' do
       let(:multipart_upload_id) { nil }
-      it { expect(subject.chunk_upload_ready?(chunk)).to eq false }
+      it { expect(subject.chunk_upload_ready?(upload)).to eq false }
     end
   end
 

--- a/spec/models/s3_storage_provider_spec.rb
+++ b/spec/models/s3_storage_provider_spec.rb
@@ -220,6 +220,17 @@ RSpec.describe S3StorageProvider, type: :model do
     end
   end
 
+  describe '#chunk_upload_ready?(chunk)' do
+    let(:upload) { FactoryBot.create(:upload, :skip_validation, multipart_upload_id: multipart_upload_id) }
+    let(:multipart_upload_id) { Faker::Lorem.characters(88) }
+    it { expect(subject.chunk_upload_ready?(chunk)).to eq true }
+
+    context 'when upload.multipart_upload_id is nil' do
+      let(:multipart_upload_id) { nil }
+      it { expect(subject.chunk_upload_ready?(chunk)).to eq false }
+    end
+  end
+
   describe '#chunk_upload_url(chunk)' do
     let(:upload) { FactoryBot.create(:upload, :skip_validation, multipart_upload_id: multipart_upload_id) }
     let(:bucket_name) { chunk.upload.storage_container }

--- a/spec/models/storage_provider_spec.rb
+++ b/spec/models/storage_provider_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe StorageProvider, type: :model do
   it { expect { subject.is_initialized?(project) }.to raise_error(NotImplementedError) }
   it { expect { subject.single_file_upload_url(upload) }.to raise_error(NotImplementedError) }
   it { expect { subject.initialize_chunked_upload(upload) }.to raise_error(NotImplementedError) }
-  it { expect { subject.chunk_upload_ready?(chunk) }.to raise_error(NotImplementedError) }
+  it { expect { subject.chunk_upload_ready?(upload) }.to raise_error(NotImplementedError) }
   it { expect { subject.chunk_upload_url(chunk) }.to raise_error(NotImplementedError) }
   it { expect { subject.chunk_max_reached?(chunk) }.to raise_error(NotImplementedError) }
   it { expect { subject.max_chunked_upload_size }.to raise_error(NotImplementedError) }

--- a/spec/models/storage_provider_spec.rb
+++ b/spec/models/storage_provider_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe StorageProvider, type: :model do
   it { expect { subject.is_initialized?(project) }.to raise_error(NotImplementedError) }
   it { expect { subject.single_file_upload_url(upload) }.to raise_error(NotImplementedError) }
   it { expect { subject.initialize_chunked_upload(upload) }.to raise_error(NotImplementedError) }
+  it { expect { subject.chunk_upload_ready?(chunk) }.to raise_error(NotImplementedError) }
   it { expect { subject.chunk_upload_url(chunk) }.to raise_error(NotImplementedError) }
   it { expect { subject.chunk_max_reached?(chunk) }.to raise_error(NotImplementedError) }
   it { expect { subject.max_chunked_upload_size }.to raise_error(NotImplementedError) }

--- a/spec/models/swift_storage_provider_spec.rb
+++ b/spec/models/swift_storage_provider_spec.rb
@@ -378,6 +378,10 @@ RSpec.describe SwiftStorageProvider, type: :model do
       end
     end
 
+    describe '#chunk_upload_ready?(chunk)' do
+      it { expect(subject.chunk_upload_ready?(chunk)).to be_truthy }
+    end
+
     describe '#chunk_upload_url(chunk)' do
       it 'should return a signed url to PUT the chunk' do
         is_expected.to receive(:build_signed_url)

--- a/spec/models/swift_storage_provider_spec.rb
+++ b/spec/models/swift_storage_provider_spec.rb
@@ -378,8 +378,8 @@ RSpec.describe SwiftStorageProvider, type: :model do
       end
     end
 
-    describe '#chunk_upload_ready?(chunk)' do
-      it { expect(subject.chunk_upload_ready?(chunk)).to be_truthy }
+    describe '#chunk_upload_ready?(upload)' do
+      it { expect(subject.chunk_upload_ready?(upload)).to be_truthy }
     end
 
     describe '#chunk_upload_url(chunk)' do

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -195,6 +195,20 @@ RSpec.describe Upload, type: :model do
     end
   end
 
+  it { is_expected.to respond_to :check_readiness! }
+  describe '#check_readiness!' do
+    let(:readiness) { true }
+    before(:example) do
+      allow(subject).to receive(:ready_for_chunks?).and_return(readiness)
+    end
+    it { expect(subject.check_readiness!).to be_truthy }
+
+    context 'when not ready' do
+      let(:readiness) { false }
+      it { expect { subject.check_readiness! }.to raise_error ConsistencyException, 'Upload is not ready' }
+    end
+  end
+
   describe '#complete' do
     let(:fingerprint_attributes) { FactoryBot.attributes_for(:fingerprint) }
     before { subject.fingerprints_attributes = [fingerprint_attributes] }

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -178,6 +178,23 @@ RSpec.describe Upload, type: :model do
     end
   end
 
+  it { is_expected.to respond_to :ready_for_chunks? }
+  describe '#ready_for_chunks?' do
+    subject { FactoryBot.create(:upload, storage_provider: mocked_storage_provider) }
+    let(:mocked_storage_provider) { FactoryBot.create(:storage_provider, :default) }
+    let(:upload_ready) { true }
+    before(:example) do
+      expect(mocked_storage_provider).to receive(:chunk_upload_ready?).with(subject) { upload_ready }
+    end
+
+    it { expect(subject.ready_for_chunks?).to eq true }
+
+    context 'when upload is not ready' do
+      let(:upload_ready) { false }
+      it { expect(subject.ready_for_chunks?).to eq false }
+    end
+  end
+
   describe '#complete' do
     let(:fingerprint_attributes) { FactoryBot.attributes_for(:fingerprint) }
     before { subject.fingerprints_attributes = [fingerprint_attributes] }

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -164,6 +164,19 @@ RSpec.describe Upload, type: :model do
     end
   end
 
+  it { is_expected.to respond_to :initialize_storage }
+  describe '#initialize_storage' do
+    subject { FactoryBot.create(:upload, storage_provider: mocked_storage_provider) }
+    let(:mocked_storage_provider) { FactoryBot.create(:storage_provider, :default) }
+
+    it 'enqueues a UploadStorageProviderInitializationJob' do
+      expect {
+        subject.initialize_storage
+      }.to have_enqueued_job(UploadStorageProviderInitializationJob)
+        .with(job_transaction: instance_of(JobTransaction), storage_provider: subject.storage_provider, upload: subject)
+    end
+  end
+
   describe '#complete' do
     let(:fingerprint_attributes) { FactoryBot.attributes_for(:fingerprint) }
     before { subject.fingerprints_attributes = [fingerprint_attributes] }

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe Upload, type: :model do
 
   describe 'callbacks' do
     it { is_expected.to callback(:set_storage_container).before(:create) }
+    it { is_expected.to callback(:initialize_storage).after(:create) }
   end
 
   describe 'instance methods' do

--- a/spec/requests/uploads_api_spec.rb
+++ b/spec/requests/uploads_api_spec.rb
@@ -222,9 +222,9 @@ describe DDS::V1::UploadsAPI do
         end
       end
 
-      context 'chunk#upload_ready? is false' do
+      context 'upload#ready_for_chunks? is false' do
         before(:example) do
-          allow_any_instance_of(Chunk).to receive(:upload_ready?).and_return(false)
+          allow_any_instance_of(Upload).to receive(:ready_for_chunks?).and_return(false)
         end
         it 'returns 404 with a consistency error message' do
           is_expected.to eq(404)

--- a/spec/requests/uploads_api_spec.rb
+++ b/spec/requests/uploads_api_spec.rb
@@ -222,6 +222,13 @@ describe DDS::V1::UploadsAPI do
         end
       end
 
+      context 'chunk#url raises ConsistencyException' do
+        before(:example) do
+          allow_any_instance_of(Chunk).to receive(:url).and_raise(ConsistencyException)
+        end
+        it { is_expected.to eq(404) }
+      end
+
       context 'chunk size too large' do
         before do
           chunk_stub.size = chunk_stub.chunk_max_size_bytes + 1

--- a/spec/requests/uploads_api_spec.rb
+++ b/spec/requests/uploads_api_spec.rb
@@ -222,11 +222,14 @@ describe DDS::V1::UploadsAPI do
         end
       end
 
-      context 'chunk#url raises ConsistencyException' do
+      context 'chunk#upload_ready? is false' do
         before(:example) do
-          allow_any_instance_of(Chunk).to receive(:url).and_raise(ConsistencyException)
+          allow_any_instance_of(Chunk).to receive(:upload_ready?).and_return(false)
         end
-        it { is_expected.to eq(404) }
+        it 'returns 404 with a consistency error message' do
+          is_expected.to eq(404)
+          expect(response.body).to include 'resource_not_consistent'
+        end
       end
 
       context 'chunk size too large' do

--- a/spec/requests/uploads_api_spec.rb
+++ b/spec/requests/uploads_api_spec.rb
@@ -151,79 +151,74 @@ describe DDS::V1::UploadsAPI do
     let!(:resource) { chunk }
     let!(:url) { "/api/v1/uploads/#{upload_id}/chunks" }
     let(:upload_id) { upload.id }
+    let(:payload) {{
+      number: payload_chunk_number,
+      size: chunk_stub.size,
+      hash: {
+        value: chunk_stub.fingerprint_value,
+        algorithm: chunk_stub.fingerprint_algorithm
+      }
+    }}
+    let(:payload_chunk_number) { chunk_stub.number }
 
-    describe 'PUT' do
-      subject { put(url, params: payload.to_json, headers: headers) }
-      let(:called_action) { "PUT" }
-      let(:payload) {{
-        number: payload_chunk_number,
-        size: chunk_stub.size,
-        hash: {
-          value: chunk_stub.fingerprint_value,
-          algorithm: chunk_stub.fingerprint_algorithm
+    it_behaves_like 'a PUT request' do
+      it_behaves_like 'a creatable resource' do
+        let(:expected_response_status) {200}
+        let(:new_object) {
+          resource_class.where(
+            upload_id: upload.id,
+            number: payload[:number],
+            size: payload[:size],
+            fingerprint_value: payload[:hash][:value],
+            fingerprint_algorithm: payload[:hash][:algorithm]
+          ).last
         }
-      }}
-      let(:payload_chunk_number) { chunk_stub.number }
+      end
 
-      it_behaves_like 'a PUT request' do
-        it_behaves_like 'a creatable resource' do
-          let(:expected_response_status) {200}
-          let(:new_object) {
-            resource_class.where(
-              upload_id: upload.id,
-              number: payload[:number],
-              size: payload[:size],
-              fingerprint_value: payload[:hash][:value],
-              fingerprint_algorithm: payload[:hash][:algorithm]
-            ).last
+      context 'retry' do
+        let(:resource) {
+          chunk_stub.save(validate: false)
+          chunk_stub
+        }
+        it_behaves_like 'a viewable resource'
+      end
+
+      context 'when chunk.number exists' do
+        let(:payload_chunk_number) { chunk.number }
+        it_behaves_like 'an updatable resource'
+      end
+
+      it_behaves_like 'a validated resource' do
+        let(:payload) {{
+          number: nil,
+          size: nil,
+          hash: {
+            value: nil,
+            algorithm: nil
           }
+        }}
+        it 'should not persist changes' do
+          expect(resource).to be_persisted
+          expect {
+            is_expected.to eq(400)
+          }.not_to change{resource_class.count}
         end
+      end
 
-        context 'retry' do
-          let(:resource) {
-            chunk_stub.save(validate: false)
-            chunk_stub
-          }
-          it_behaves_like 'a viewable resource'
-        end
+      it_behaves_like 'an authenticated resource'
+      it_behaves_like 'an authorized resource'
 
-        context 'when chunk.number exists' do
-          let(:payload_chunk_number) { chunk.number }
-          it_behaves_like 'an updatable resource'
-        end
+      it_behaves_like 'an identified resource' do
+        let(:upload_id) { "doesNotExist" }
+        let(:resource_class) {"Upload"}
+      end
 
-        it_behaves_like 'a validated resource' do
-          let(:payload) {{
-            number: nil,
-            size: nil,
-            hash: {
-              value: nil,
-              algorithm: nil
-            }
-          }}
-          it 'should not persist changes' do
-            expect(resource).to be_persisted
-            expect {
-              is_expected.to eq(400)
-            }.not_to change{resource_class.count}
-          end
-        end
-
-        it_behaves_like 'an authenticated resource'
-        it_behaves_like 'an authorized resource'
-
-        it_behaves_like 'an identified resource' do
-          let(:upload_id) { "doesNotExist" }
-          let(:resource_class) {"Upload"}
-        end
-
+      it_behaves_like 'an annotate_audits endpoint' do
+        let(:resource_class) { Chunk }
+      end
+      it_behaves_like 'a software_agent accessible resource' do
         it_behaves_like 'an annotate_audits endpoint' do
           let(:resource_class) { Chunk }
-        end
-        it_behaves_like 'a software_agent accessible resource' do
-          it_behaves_like 'an annotate_audits endpoint' do
-            let(:resource_class) { Chunk }
-          end
         end
       end
 

--- a/spec/serializers/upload_serializer_spec.rb
+++ b/spec/serializers/upload_serializer_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe UploadSerializer, type: :serializer do
     'etag' => resource.etag,
     'status' => {
       'initiated_on' => resource.created_at.as_json,
+      'ready_for_chunks' => resource.ready_for_chunks?.as_json,
       'completed_on' => resource.completed_at.as_json,
       'purged_on' => resource.purged_on.as_json,
       'error_on' => resource.error_at.as_json,
@@ -34,6 +35,15 @@ RSpec.describe UploadSerializer, type: :serializer do
 
   context 'with completed upload' do
     let(:resource) { FactoryBot.create(:upload, :with_chunks, :completed, :with_fingerprint, storage_provider: mocked_storage_provider) }
+    it_behaves_like 'a json serializer' do
+      it { is_expected.to include(expected_attributes) }
+    end
+  end
+
+  context 'when upload is not ready for chunks' do
+    before(:example) do
+      allow(resource).to receive(:ready_for_chunks?).and_return(false)
+    end
     it_behaves_like 'a json serializer' do
       it { is_expected.to include(expected_attributes) }
     end

--- a/spec/serializers/upload_serializer_spec.rb
+++ b/spec/serializers/upload_serializer_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe UploadSerializer, type: :serializer do
       'initiated_on' => resource.created_at.as_json,
       'ready_for_chunks' => resource.ready_for_chunks?.as_json,
       'completed_on' => resource.completed_at.as_json,
+      'is_consistent' => resource.is_consistent.as_json,
       'purged_on' => resource.purged_on.as_json,
       'error_on' => resource.error_at.as_json,
       'error_message' => resource.error_message
@@ -35,6 +36,13 @@ RSpec.describe UploadSerializer, type: :serializer do
 
   context 'with completed upload' do
     let(:resource) { FactoryBot.create(:upload, :with_chunks, :completed, :with_fingerprint, storage_provider: mocked_storage_provider) }
+    it_behaves_like 'a json serializer' do
+      it { is_expected.to include(expected_attributes) }
+    end
+  end
+
+  context 'with inconsistent upload' do
+    let(:resource) { FactoryBot.create(:upload, :with_chunks, :inconsistent, storage_provider: mocked_storage_provider) }
     it_behaves_like 'a json serializer' do
       it { is_expected.to include(expected_attributes) }
     end

--- a/spec/services/jobs_runner_spec.rb
+++ b/spec/services/jobs_runner_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe JobsRunner do
   let(:workers_registry_hash) { {
     message_logger: MessageLogWorker,
     initialize_project_storage: ProjectStorageProviderInitializationJob,
+    initialize_upload_storage: UploadStorageProviderInitializationJob,
     delete_children: ChildDeletionJob,
     index_documents: ElasticsearchIndexJob,
     update_project_container_elasticsearch: ProjectContainerElasticsearchUpdateJob,

--- a/spec/support/concerns/storage_provider_shared_examples.rb
+++ b/spec/support/concerns/storage_provider_shared_examples.rb
@@ -140,7 +140,7 @@ shared_examples 'A StorageProvider implementation' do
     it { expect { subject.suggested_minimum_chunk_size(nil) }.not_to raise_error(NotImplementedError) }
   end
 
-  describe '#chunk_upload_ready?(chunk)' do
+  describe '#chunk_upload_ready?(upload)' do
     it { expect { subject.chunk_upload_ready?(nil) }.not_to raise_error(NotImplementedError) }
   end
 

--- a/spec/support/concerns/storage_provider_shared_examples.rb
+++ b/spec/support/concerns/storage_provider_shared_examples.rb
@@ -17,6 +17,7 @@ shared_context 'mocked StorageProvider Interface' do
       filename ||= upload.name
       "#{expected_url_root}/#{URI.encode(filename)}"
     end
+    allow(mocked_storage_provider).to receive(:chunk_upload_ready?).and_return(true)
     allow(mocked_storage_provider).to receive(:chunk_upload_url) do |chunk|
       "#{expected_url_root}/#{chunk.sub_path}"
     end

--- a/spec/support/concerns/storage_provider_shared_examples.rb
+++ b/spec/support/concerns/storage_provider_shared_examples.rb
@@ -86,6 +86,7 @@ shared_context 'A StorageProvider' do
   it { is_expected.to respond_to(:complete_chunked_upload).with(1).argument }
   it { is_expected.to respond_to(:is_complete_chunked_upload?).with(1).argument }
   it { is_expected.to respond_to(:chunk_upload_url).with(1).argument }
+  it { is_expected.to respond_to(:chunk_upload_ready?).with(1).argument }
   it { is_expected.to respond_to(:max_chunked_upload_size) }
   it { is_expected.to respond_to(:suggested_minimum_chunk_size).with(1).argument }
   it { is_expected.to respond_to(:download_url).with(1).argument }
@@ -136,6 +137,10 @@ shared_examples 'A StorageProvider implementation' do
 
   describe '#suggested_minimum_chunk_size' do
     it { expect { subject.suggested_minimum_chunk_size(nil) }.not_to raise_error(NotImplementedError) }
+  end
+
+  describe '#chunk_upload_ready?(chunk)' do
+    it { expect { subject.chunk_upload_ready?(nil) }.not_to raise_error(NotImplementedError) }
   end
 
   describe '#chunk_upload_url(chunk)' do


### PR DESCRIPTION
- [x] Add Upload#initialize_storage method
- [x] Create background job to call Upload#initialize_storage
- [x] Perform job after Upload#create
- [x] Update S3StorageProvider#chunk_upload_url to throw exception when Upload#multipart_upload_id is not set
- [x] Raise ConsistencyException when attempting to create a chunk for an upload that is not ready
- [x] Upload#ready_for_chunks? method
- [x] Upload serializer status hash includes :ready_for_chunks and :is_consistent