### PR TITLE
DDS-1172 Fix CircleCi Bundler issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
             0.0.0.0       rabbitmq.local
             ' | tee -a /etc/hosts
 
-      - run: gem install bundler
+      - run: gem install bundler -v '~> 1.17.0'
       - run:
           name: Which bundler?
           command: bundle -v


### PR DESCRIPTION
The call to `gem install bundler` is failing with:
ERROR: Error installing bundler:
The last version of bundler (>= 0) to support your Ruby & RubyGems was 1.17.3. Try installing it with `gem install bundler -v 1.17.3`
bundler requires RubyGems version >= 3.0.0. The current RubyGems version is 2.7.6. Try 'gem update --system' to update RubyGems itself. 