### PR TITLE
DDS-1178 Remove index option from neo4j models

### DIFF
--- a/app/models/graph/activity.rb
+++ b/app/models/graph/activity.rb
@@ -1,8 +1,8 @@
 class Graph::Activity
   include Graphed::NodeModel
 
-  property :model_id, index: :exact
-  property :model_kind, index: :exact
-  property :is_deleted, index: :exact
+  property :model_id
+  property :model_kind
+  property :is_deleted
   self.mapped_label_name = 'Activity'
 end

--- a/app/models/graph/agent.rb
+++ b/app/models/graph/agent.rb
@@ -1,7 +1,7 @@
 class Graph::Agent
   include Graphed::NodeModel
 
-  property :model_id, index: :exact
-  property :model_kind, index: :exact
+  property :model_id
+  property :model_kind
   self.mapped_label_name = 'Agent'
 end

--- a/app/models/graph/file_version.rb
+++ b/app/models/graph/file_version.rb
@@ -1,8 +1,8 @@
 class Graph::FileVersion
   include Graphed::NodeModel
 
-  property :model_id, index: :exact
-  property :model_kind, index: :exact
-  property :is_deleted, index: :exact
+  property :model_id
+  property :model_kind
+  property :is_deleted
   self.mapped_label_name = 'FileVersion'
 end


### PR DESCRIPTION
This PR addresses the following deprecation warning was appearing in the logs:
```
WARNING: The index option is no longer supported (Defined on Graph::Activity for model_id)
```

Relevant GitHub issue:
https://github.com/neo4jrb/neo4j/issues/1449