### PR TITLE
Deploy v1.10.8 to ua_test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'neo4j', '~> 9.0'
 
 # Use sneakers(RabbitMQ) for background jobs
 gem 'sneakers', '~> 2.11.0'
+gem 'sneakers_handlers', '~> 0.0.6'
 
 # User ldap for ldap_identity_provider searches
 gem 'net-ldap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,6 +329,8 @@ GEM
       rake
       serverengine (~> 2.0.5)
       thor
+    sneakers_handlers (0.0.6)
+      sneakers
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-commands-rspec (1.0.4)
@@ -409,6 +411,7 @@ DEPENDENCIES
   shoulda-callback-matchers (~> 1.1, >= 1.1.3)
   shoulda-matchers
   sneakers (~> 2.11.0)
+  sneakers_handlers (~> 0.0.6)
   spring
   spring-commands-rspec
   turbolinks

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -41,8 +41,8 @@ class ApplicationJob < ActiveJob::Base
     klass = self
     Class.new(ActiveJob::QueueAdapters::SneakersAdapter::JobWrapper) do
       from_queue klass.queue_name,
-        max_retries: 10,
-        backoff_function: -> (attempt_number) { 2 ** attempt_number },
+        max_retries: 6,
+        backoff_function: -> (attempt_number) { 5 ** attempt_number },
         arguments: {
           'x-dead-letter-exchange' => "#{klass.queue_name}.dlx",
           'x-dead-letter-routing-key' => "#{klass.queue_name}"

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -12,28 +12,6 @@ class ApplicationJob < ActiveJob::Base
     end
   end
 
-  rescue_from(ActiveJob::DeserializationError) do |e|
-    if @deserialization_error_retried
-      raise e
-    else
-      @deserialization_error_retried = true
-      self.class.wait ApplicationJob.deserialization_error_retry_interval
-      self.perform_now
-    end
-  end
-
-  def self.deserialization_error_retry_interval=(val)
-    @deserialization_error_retry_interval = Integer(val)
-  end
-
-  def self.deserialization_error_retry_interval
-    @deserialization_error_retry_interval || 1
-  end
-
-  def self.wait(interval)
-    sleep interval
-  end
-
   def self.distributor_exchange_name
     'active_jobs'
   end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -41,7 +41,6 @@ class ApplicationJob < ActiveJob::Base
     klass = self
     Class.new(ActiveJob::QueueAdapters::SneakersAdapter::JobWrapper) do
       from_queue klass.queue_name,
-        max_retries: 6,
         backoff_function: -> (attempt_number) { 5 ** attempt_number },
         arguments: {
           'x-dead-letter-exchange' => "#{klass.queue_name}.dlx",

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -41,6 +41,7 @@ class ApplicationJob < ActiveJob::Base
     klass = self
     Class.new(ActiveJob::QueueAdapters::SneakersAdapter::JobWrapper) do
       from_queue klass.queue_name,
+        max_retries: 10,
         backoff_function: -> (attempt_number) { 2 ** attempt_number },
         arguments: {
           'x-dead-letter-exchange' => "#{klass.queue_name}.dlx",

--- a/app/services/error_queue_handler.rb
+++ b/app/services/error_queue_handler.rb
@@ -1,5 +1,6 @@
 class ErrorQueueHandler
   def message_count
+    raise "ErrorQueueHandler is deprecated due to incompatibilities with the ExponentialBackoffHandler."
     count = 0
     with_error_queue do |error_queue|
       count = error_queue.message_count
@@ -8,6 +9,7 @@ class ErrorQueueHandler
   end
 
   def messages(routing_key: nil, limit: nil)
+    raise "ErrorQueueHandler is deprecated due to incompatibilities with the ExponentialBackoffHandler."
     msgs = []
     each_error_queue_message do |msg|
       msgs << serialize_message(msg) unless routing_key &&
@@ -18,6 +20,7 @@ class ErrorQueueHandler
   end
 
   def requeue_message(id)
+    raise "ErrorQueueHandler is deprecated due to incompatibilities with the ExponentialBackoffHandler."
     message = nil
     msgs = []
     each_error_queue_message do |msg, channel, delivery_tags|
@@ -33,6 +36,7 @@ class ErrorQueueHandler
   end
 
   def requeue_all
+    raise "ErrorQueueHandler is deprecated due to incompatibilities with the ExponentialBackoffHandler."
     msgs = []
     each_error_queue_message do |msg, channel, delivery_tags|
       msgs << serialize_message(msg)
@@ -43,6 +47,7 @@ class ErrorQueueHandler
   end
 
   def requeue_messages(routing_key:, limit: nil)
+    raise "ErrorQueueHandler is deprecated due to incompatibilities with the ExponentialBackoffHandler."
     msgs = []
     each_error_queue_message do |msg, channel, delivery_tags|
       if msg.first[:routing_key] == routing_key

--- a/app/workers/message_log_worker.rb
+++ b/app/workers/message_log_worker.rb
@@ -1,7 +1,10 @@
 class MessageLogWorker
   include Sneakers::Worker
   from_queue 'message_log',
-    :retry_error_exchange => 'message_log-error'
+    arguments: {
+      'x-dead-letter-exchange' => "message_log.dlx",
+      'x-dead-letter-routing-key' => "message_log"
+    }
 
   def work_with_params(msg, delivery_info, metadata)
     begin

--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -20,6 +20,7 @@ Sneakers.configure(
     :type => :fanout
   },
   :handler => SneakersHandlers::ExponentialBackoffHandler,
+  :max_retries => 6,
 
   # runner
   #:runner_config_file => nil,

--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -12,8 +12,6 @@ sneakers_timeout_job_after = ENV['SNEAKERS_TIMEOUT_JOB_AFTER'] || 60
 sneakers_connection_threaded = ENV['SNEAKERS_SINGLE_THREADED_CONNECTION'] ? false : true
 sneakers_connection_continuation_timeout = ENV['SNEAKERS_CONNECTION_CONTINUATION'] || 4000
 
-ApplicationJob.deserialization_error_retry_interval = ENV['APPLICATION_JOB_DESERIALIZATION_ERROR_RETRY_INTERVAL'] if ENV['APPLICATION_JOB_DESERIALIZATION_ERROR_RETRY_INTERVAL']
-
 Sneakers.configure(
   :exchange => 'message_gateway',
   :exchange_options => {

--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -19,8 +19,7 @@ Sneakers.configure(
   :exchange_options => {
     :type => :fanout
   },
-  :handler => Sneakers::Handlers::Maxretry,
-  :retry_error_exchange => 'active_jobs-error',
+  :handler => SneakersHandlers::ExponentialBackoffHandler,
 
   # runner
   #:runner_config_file => nil,

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -174,6 +174,18 @@ RSpec.describe ApplicationJob, type: :job do
         job_wrapper
       end
       it { expect(bunny_session.queue_exists?(prefixed_queue_name)).to be_falsey }
+      context 'instance backoff_function' do
+        let(:job_wrapper_instance) { child_class.job_wrapper.new }
+        let(:backoff_function) { job_wrapper_instance.opts[:backoff_function] }
+        let(:backoff_seq) { [1, 2, 4, 8, 16] }
+        it { expect(backoff_function).to respond_to(:call).with(1).argument }
+        # 2^x
+        it { expect(backoff_function.call(0)).to eq(backoff_seq[0]) }
+        it { expect(backoff_function.call(1)).to eq(backoff_seq[1]) }
+        it { expect(backoff_function.call(2)).to eq(backoff_seq[2]) }
+        it { expect(backoff_function.call(3)).to eq(backoff_seq[3]) }
+        it { expect(backoff_function.call(4)).to eq(backoff_seq[4]) }
+      end
       context 'instance created and run' do
         let(:job_wrapper_instance) { child_class.job_wrapper.new }
         before { job_wrapper_instance.run }

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -178,15 +178,15 @@ RSpec.describe ApplicationJob, type: :job do
       describe 'instance max_retries' do
         let(:job_wrapper_instance) { child_class.job_wrapper.new }
         let(:max_retries) { job_wrapper_instance.opts[:max_retries] }
-        it { expect(max_retries).to eq(10) }
+        it { expect(max_retries).to eq(6) }
       end
 
       describe 'instance backoff_function' do
         let(:job_wrapper_instance) { child_class.job_wrapper.new }
         let(:backoff_function) { job_wrapper_instance.opts[:backoff_function] }
-        let(:backoff_seq) { [1, 2, 4, 8, 16] }
+        let(:backoff_seq) { [1, 5, 25, 125, 625] }
         it { expect(backoff_function).to respond_to(:call).with(1).argument }
-        # 2^x
+        # 5^x
         it { expect(backoff_function.call(0)).to eq(backoff_seq[0]) }
         it { expect(backoff_function.call(1)).to eq(backoff_seq[1]) }
         it { expect(backoff_function.call(2)).to eq(backoff_seq[2]) }

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -174,7 +174,14 @@ RSpec.describe ApplicationJob, type: :job do
         job_wrapper
       end
       it { expect(bunny_session.queue_exists?(prefixed_queue_name)).to be_falsey }
-      context 'instance backoff_function' do
+
+      describe 'instance max_retries' do
+        let(:job_wrapper_instance) { child_class.job_wrapper.new }
+        let(:max_retries) { job_wrapper_instance.opts[:max_retries] }
+        it { expect(max_retries).to eq(10) }
+      end
+
+      describe 'instance backoff_function' do
         let(:job_wrapper_instance) { child_class.job_wrapper.new }
         let(:backoff_function) { job_wrapper_instance.opts[:backoff_function] }
         let(:backoff_seq) { [1, 2, 4, 8, 16] }
@@ -186,6 +193,7 @@ RSpec.describe ApplicationJob, type: :job do
         it { expect(backoff_function.call(3)).to eq(backoff_seq[3]) }
         it { expect(backoff_function.call(4)).to eq(backoff_seq[4]) }
       end
+
       context 'instance created and run' do
         let(:job_wrapper_instance) { child_class.job_wrapper.new }
         before { job_wrapper_instance.run }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -126,4 +126,11 @@ module BunnyMock
       r
     end
   end
+
+  class Exchange
+    def add_route(key, xchg_or_queue)
+      @routes[key] ||= []
+      @routes[key] << xchg_or_queue unless @routes[key].include?(xchg_or_queue)
+    end
+  end
 end

--- a/spec/requests/app_api_spec.rb
+++ b/spec/requests/app_api_spec.rb
@@ -120,11 +120,8 @@ describe DDS::V1::AppAPI do
       include_context 'storage_provider setup'
 
       let(:gateway_exchange_name) { Sneakers::CONFIG[:exchange] }
-      let(:retry_error_exchange_name) { Sneakers::CONFIG[:retry_error_exchange] }
       let(:distributor_exchange_name) { ApplicationJob.distributor_exchange_name }
       let(:message_log_worker_queue_name) { MessageLogWorker.new.queue.name }
-      let(:message_log_worker_retry_queue_name) { "#{MessageLogWorker.new.queue.name}-retry" }
-      let(:retry_error_queue_name) { Sneakers::CONFIG[:retry_error_exchange] }
 
       context 'environment is not set' do
         let(:status_error) { 'queue environment is not set' }
@@ -149,15 +146,12 @@ describe DDS::V1::AppAPI do
       end
 
       it_behaves_like 'it requires exchange', :gateway_exchange_name
-      it_behaves_like 'it requires exchange', :retry_error_exchange_name
       it_behaves_like 'it requires exchange', :distributor_exchange_name
 
       it_behaves_like 'it requires queue', :message_log_worker_queue_name
-      it_behaves_like 'it requires queue', :message_log_worker_retry_queue_name
-      it_behaves_like 'it requires queue', :retry_error_queue_name
 
       (ApplicationJob.descendants.collect {|d|
-        [d.queue_name, "#{d.queue_name}-retry"]
+        [d.queue_name]
       }).flatten.uniq.each do |this_queue|
         let(:job_queue) { this_queue }
         it_behaves_like 'it requires queue', :job_queue

--- a/spec/workers/message_log_worker_spec.rb
+++ b/spec/workers/message_log_worker_spec.rb
@@ -3,7 +3,10 @@ require 'rails_helper'
 RSpec.describe MessageLogWorker do
   let(:gateway_exchange_name) { Sneakers::CONFIG[:exchange] }
   let(:queue_name) { 'message_log' }
-  let(:error_exchange) { "#{queue_name}-error" }
+  let(:queue_arguments) { {
+    'x-dead-letter-exchange' => "#{queue_name}.dlx",
+    'x-dead-letter-routing-key' => queue_name
+  } }
 
   it { expect(described_class).to include(Sneakers::Worker) }
   it { expect(subject.queue.name).to eq(queue_name) }
@@ -11,7 +14,7 @@ RSpec.describe MessageLogWorker do
   it { expect(subject.opts[:exchange_options][:type]).to eq(:fanout) }
   it { expect(subject.opts[:exchange_options][:durable]).to be_truthy }
   it { expect(subject.opts[:exchange_options][:durable]).to be_truthy }
-  it { expect(subject.opts[:retry_error_exchange]).to eq(error_exchange) }
+  it { expect(subject.opts[:queue_options][:arguments]).to eq(queue_arguments) }
 
   it { is_expected.not_to respond_to(:work) }
   it { is_expected.to respond_to(:work_with_params).with(3).arguments }


### PR DESCRIPTION
Retry jobs with exponential backoff
DEPLOYMENT NOTE: Spin down all dynos before deploying. All queues must be deleted before dynos can be spun back up.