### PR TITLE
DDS-1187 configure s3 bucket addressing

### DIFF
--- a/app/models/s3_storage_provider.rb
+++ b/app/models/s3_storage_provider.rb
@@ -133,7 +133,7 @@ class S3StorageProvider < StorageProvider
   def client
     @client ||= Aws::S3::Client.new(
       region: 'us-east-1',
-      force_path_style: true,
+      force_path_style: force_path_style.nil? || force_path_style,
       access_key_id: service_user,
       secret_access_key: service_pass,
       endpoint: url_root

--- a/db/migrate/20190304211844_add_force_path_style_to_storage_providers.rb
+++ b/db/migrate/20190304211844_add_force_path_style_to_storage_providers.rb
@@ -1,0 +1,5 @@
+class AddForcePathStyleToStorageProviders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :storage_providers, :force_path_style, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_19_200627) do
+ActiveRecord::Schema.define(version: 2019_03_04_211844) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -290,6 +290,7 @@ ActiveRecord::Schema.define(version: 2019_02_19_200627) do
     t.bigint "chunk_max_size_bytes"
     t.string "type"
     t.boolean "is_default"
+    t.boolean "force_path_style"
   end
 
   create_table "system_permissions", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/spec/lib/tasks/job_transaction_rake_spec.rb
+++ b/spec/lib/tasks/job_transaction_rake_spec.rb
@@ -26,7 +26,7 @@ describe 'job_transaction:clean_up:completed' do
   end
 
   context 'when oldest completed from 4 months ago' do
-    let(:oldest_completed_at) { Time.now - 4.month - 1.day }
+    let(:oldest_completed_at) { Time.now - 4.month - 2.day }
     let(:deleted_counts) { Array.new(4) { Faker::Number.between(0, 1000) } }
     before(:each) do
       4.times do |i|
@@ -67,7 +67,7 @@ describe 'job_transaction:clean_up:orphans' do
   end
 
   context 'when oldest orphan from 4 months ago' do
-    let(:oldest_orphan_created_at) { Time.now - 4.month - 1.day }
+    let(:oldest_orphan_created_at) { Time.now - 4.month - 2.day }
     let(:deleted_counts) { Array.new(4) { Faker::Number.between(0, 999) } }
     before(:each) do
       4.times do |i|
@@ -87,7 +87,7 @@ describe 'job_transaction:clean_up:orphans' do
       'BATCH_SIZE' => batch_size
     } }
     let(:a_month_ago) { Time.now - 1.month }
-    let(:oldest_orphan_created_at) { a_month_ago - 1.day }
+    let(:oldest_orphan_created_at) { a_month_ago - 3.day }
     let(:deleted_count) { 5 }
     before(:each) do
       expect(JobTransaction).to receive(:delete_all_orphans).with(created_before: a_month_ago, limit: batch_size).and_return(batch_size).ordered
@@ -124,7 +124,7 @@ describe 'job_transaction:clean_up:logical_orphans' do
   end
 
   context 'when oldest logical orphan from 4 months ago' do
-    let(:oldest_logical_orphan_created_at) { Time.now - 4.month - 1.day }
+    let(:oldest_logical_orphan_created_at) { Time.now - 4.month - 2.day }
     let(:deleted_counts) { Array.new(4) { Faker::Number.between(0, 1000) } }
     before(:each) do
       4.times do |i|
@@ -144,7 +144,7 @@ describe 'job_transaction:clean_up:all' do
 
   let(:default_batch_size) { 50000 }
   let(:a_month_ago) { Time.now - 1.month }
-  let(:just_over_a_month_ago) { Time.now - 1.month - 1.day }
+  let(:just_over_a_month_ago) { Time.now - 1.month - 3.day }
   around(:each) do |example|
     travel_to(Time.now) do #freeze_time
       example.run

--- a/spec/models/s3_storage_provider_spec.rb
+++ b/spec/models/s3_storage_provider_spec.rb
@@ -368,6 +368,21 @@ RSpec.describe S3StorageProvider, type: :model do
     it { expect(subject.client.config.access_key_id).to eq subject.service_user }
     it { expect(subject.client.config.secret_access_key).to eq subject.service_pass }
     it { expect(subject.client.config.endpoint).to eq uri_parsed_url_root }
+    context 'with #force_path_style' do
+      before(:example) { subject.force_path_style = path_style }
+      context 'set to true' do
+        let(:path_style) { true }
+        it { expect(subject.client.config.force_path_style).to be_truthy }
+      end
+      context 'set to false' do
+        let(:path_style) { false }
+        it { expect(subject.client.config.force_path_style).to be_falsey  }
+      end
+      context 'set to nil' do
+        let(:path_style) { nil }
+        it { expect(subject.client.config.force_path_style).to be_truthy }
+      end
+    end
     it 'reuses the same client object' do
       expect(subject.client).to eq(subject.client)
     end


### PR DESCRIPTION
Adding a field to allow S3StorageProvider use virtual host style bucket addressing instead of path style bucket addressing. For backwards compatibility, path style is the default. If it's determined that virtual host style should be the default, that can be addressed in a future PR.