### PR TITLE
DDS-1196 Fix Safari S3 CORS issue

### DIFF
--- a/app/models/s3_storage_provider.rb
+++ b/app/models/s3_storage_provider.rb
@@ -191,6 +191,7 @@ class S3StorageProvider < StorageProvider
         bucket: bucket_name,
         cors_configuration: {
           cors_rules: [{
+            allowed_headers: ['*'],
             allowed_methods: ['GET','PUT','HEAD','POST','DELETE'],
             allowed_origins: ['*']
           }]

--- a/spec/models/s3_storage_provider_spec.rb
+++ b/spec/models/s3_storage_provider_spec.rb
@@ -544,6 +544,7 @@ RSpec.describe S3StorageProvider, type: :model do
     include_context 'stubbed subject#client'
     let(:bucket_name) { SecureRandom.uuid }
     let(:cors_rule) { {
+      allowed_headers: ['*'],
       allowed_methods: %w(GET PUT HEAD POST DELETE),
       allowed_origins: ['*']
     } }


### PR DESCRIPTION
Safari requires allowed_headers to be set in CORS config...

DEPLOYMENT INSTRUCTIONS:
Paste the following in a `rails c` console for the appropriate heroku app:
```
s3 = S3StorageProvider.first
ProjectStorageProvider.where(storage_provider: s3).update_all(is_initialized: false)
s3.project_storage_providers.each {|psp| psp.touch && psp.initialize_storage}
```