### PR TITLE
DDS-1195 Purge non-chunked uploads issue

### DIFF
--- a/app/models/swift_storage_provider.rb
+++ b/app/models/swift_storage_provider.rb
@@ -128,9 +128,9 @@ class SwiftStorageProvider < StorageProvider
   end
 
   def purge(object)
-    raise "#{object} is not purgable" unless object.is_a?(ChunkedUpload) || object.is_a?(Chunk)
+    raise "#{object} is not purgable" unless object.is_a?(Upload) || object.is_a?(Chunk)
     begin
-      if object.is_a? ChunkedUpload
+      if object.is_a? Upload
         delete_object_manifest(object.storage_container, object.id)
       else
         delete_object(object.storage_container, object.object_path)

--- a/spec/models/s3_storage_provider_spec.rb
+++ b/spec/models/s3_storage_provider_spec.rb
@@ -443,6 +443,23 @@ RSpec.describe S3StorageProvider, type: :model do
       end
     end
 
+    context 'non_chunked_upload' do
+      let(:bucket_name) { non_chunked_upload.storage_container }
+      let(:object_key) { non_chunked_upload.id }
+      let(:response) { {} }
+      before(:example) do
+        expect(subject).to receive(:delete_object)
+          .with(bucket_name, object_key) { response }
+      end
+
+      it { expect(subject.purge(non_chunked_upload)).to be_truthy }
+
+      context 'unexpected StorageProviderException' do
+        let(:response) { raise StorageProviderException.new('Unexpected') }
+        it { expect { subject.purge(non_chunked_upload) }.to raise_error(StorageProviderException, 'Unexpected') }
+      end
+    end
+
     context 'chunk' do
       before(:example) do
         expect(subject).not_to receive(:delete_object)

--- a/spec/models/swift_storage_provider_spec.rb
+++ b/spec/models/swift_storage_provider_spec.rb
@@ -500,6 +500,19 @@ RSpec.describe SwiftStorageProvider, type: :model do
         end
       end
 
+      context 'non_chunked_upload' do
+        it 'should delete the SLO manifest' do
+          is_expected.to receive(:delete_object_manifest)
+            .with(
+              non_chunked_upload.storage_container,
+              non_chunked_upload.id
+            )
+          expect {
+            subject.purge(non_chunked_upload)
+          }.not_to raise_error
+        end
+      end
+
       context 'chunk' do
         it 'should delete the object' do
           is_expected.to receive(:delete_object)
@@ -510,14 +523,6 @@ RSpec.describe SwiftStorageProvider, type: :model do
           expect {
             subject.purge(chunk)
           }.not_to raise_error
-        end
-      end
-
-      context 'non_chunked_upload' do
-        it 'should raise an Exception' do
-          expect {
-            subject.purge(non_chunked_upload)
-          }.to raise_error("#{non_chunked_upload} is not purgable")
         end
       end
 


### PR DESCRIPTION
Fixing a bug that prevented non-chunked uploads from being purged from Swift storage providers.