### PR TITLE
Heroku-16 Stack Migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
   sync_bot:
     docker:
-      - image: ruby:2.3.6
+      - image: ruby:2.6.3-stretch
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3
@@ -55,7 +55,7 @@ jobs:
 
     docker:
       # Copied from rails circle demo
-      - image: ruby:2.3.6
+      - image: ruby:2.6.3-stretch
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3
@@ -190,7 +190,7 @@ jobs:
 
   coverage:
     docker:
-      - image: ruby:2.3.6
+      - image: ruby:2.6.3-stretch
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3
@@ -234,7 +234,7 @@ jobs:
 
   upload_coverage:
     docker:
-      - image: ruby:2.3.6
+      - image: ruby:2.6.3-stretch
     steps:
       - attach_workspace:
           at: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ruby:2.3.6
+# Heroku-16 is based on Ubuntu 16.4
+# Debian Stretch is the upstream of Ubuntu 16.4
+FROM ruby:2.6.3-stretch
 MAINTAINER Darin London <darin.london@duke.edu>
 
 RUN ["mkdir", "-p", "/root/installs"]

--- a/Gemfile
+++ b/Gemfile
@@ -106,4 +106,4 @@ end
 group :docker, :development, :ua_test, :production do
   gem 'rails_12factor'
 end
-ruby "2.3.6"
+ruby "2.6.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -433,7 +433,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.3.6p384
+   ruby 2.6.3p62
 
 BUNDLED WITH
    1.16.1

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ machine:
   # Version of ruby to use
   ruby:
     version:
-      2.3.6
+      2.6.3
 
 dependencies:
   cache_directories:

--- a/circle/run_dredd.circle.sh
+++ b/circle/run_dredd.circle.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # cache necessary images
-./docker/circle/cache_docker_image.sh ruby 2.3.6
+./docker/circle/cache_docker_image.sh ruby 2.6.3
 ./docker/circle/cache_docker_image.sh postgres 9.4
 ./docker/circle/cache_docker_image.sh ubuntu 14.04
 ./docker/circle/cache_dredd.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   localdev:
     #make sure image matches what the root Dockerfile is FROM
-    image: ruby:2.3.6
+    image: ruby:2.6.3-stretch
     command: ['echo','setting up localdev']
     volumes:
       - .:/var/www/app

--- a/docker/circle/cache_ruby.sh
+++ b/docker/circle/cache_ruby.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
 
-docker images ruby:2.3.6 | grep ruby
+ruby_image=$(grep FROM Dockerfile | cut -d' ' -f2)
+tarfile="$(echo $ruby_image | sed 's/\:/_/g').tgz"
+docker images "${ruby_image}" | grep ruby
 if [ $? -gt 0 ]
 then
-  if [ ! -e docker/circle/ruby_2.3.6.docker.tgz ]
+  if [ ! -e docker/circle/${tarfile} ]
   then
-    echo "pulling and caching ruby:2.3.6" >&2
-    docker pull ruby:2.3.6
-    docker save ruby:2.3.6 | gzip > docker/circle/ruby_2.3.6.docker.tgz
+    echo "pulling and caching ${ruby_image}" >&2
+    docker pull ${ruby_image}
+    docker save ${ruby_image} | gzip > docker/circle/${tarfile}
   fi
-  echo "loading cached ruby:2.3.6" >&2
-  docker load -i docker/circle/ruby_2.3.6.docker.tgz
+  echo "loading cached ${ruby_image}" >&2
+  docker load -i docker/circle/${tarfile}
 fi
-echo "ruby:2.3.6 installed" >&2
+echo "${ruby_image} installed" >&2


### PR DESCRIPTION
updated to use ruby 2.6.3 and use the debian stretch based ruby:2.6.3-stretch base image in our local docker image

Debian stretch is the upstream of Ubuntu 16.4, which is what the Heroku-16 stack is based upon. This should make our local docker image similar to the heroku environment