### PR TITLE
Force Redeployment on Duke Heroku

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,7 +207,7 @@ GEM
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,8 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
     mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
@@ -449,4 +451,4 @@ RUBY VERSION
    ruby 2.6.4p104
 
 BUNDLED WITH
-   1.16.1
+   1.17.2


### PR DESCRIPTION
Merge this empty pull request to force a redeploy on Heroku to heroku-20.

heroku-16 is already past end-of-life and is no longer receiving security updates.  After June 1, 2020, all new builds with heroku-16 will fail.